### PR TITLE
Sekarang bisa menampilkan submenu jenis asuransi di halaman web

### DIFF
--- a/donjo-app/models/Laporan_penduduk_model.php
+++ b/donjo-app/models/Laporan_penduduk_model.php
@@ -210,7 +210,8 @@
 			"statistik/2"  => "Status Perkawinan",
 			"statistik/13" => "Umur",
 			"statistik/18" => "Kepemilikan Wajib KTP",
-			"statistik/5"  => "Warga Negara"
+			"statistik/5"  => "Warga Negara",
+			"statistik/19" => "Asuransi"
 		);
 		return $statistik;
 	}


### PR DESCRIPTION
Perbaikan issue #2464, Sekarang bisa menampilkan submenu jenis asuransi di halaman web

![Asuransi](https://user-images.githubusercontent.com/10391199/68473262-1241cf80-0255-11ea-9196-b91bec7ecc6e.PNG)
