### PR TITLE
#2706 Autocomplete

### DIFF
--- a/donjo-app/models/Modul_model.php
+++ b/donjo-app/models/Modul_model.php
@@ -101,8 +101,7 @@
 
 	public function autocomplete()
 	{
-		$sql = "SELECT modul FROM setting_modul WHERE hidden = 0
-					UNION SELECT url FROM setting_modul WHERE  hidden = 0";
+		$sql = "SELECT modul FROM setting_modul WHERE hidden = 0 AND parent = 0";
 		$query = $this->db->query($sql);
 		$data = $query->result_array();
 

--- a/donjo-app/views/setting/modul/table.php
+++ b/donjo-app/views/setting/modul/table.php
@@ -40,6 +40,16 @@
 			$('#offline_ada_hosting').hide();
 		}
 	}
+	
+	$(function()
+	{
+		var keyword = <?= $keyword?> ;
+		$( "#cari" ).autocomplete(
+		{
+			source: keyword,
+			maxShowItems: 10,
+		});
+	});
 </script>
 <div class="content-wrapper">
 	<section class="content-header">


### PR DESCRIPTION
Solusi untuk issue #2706

Ada Helper autocompleate tp tdk sy gunakan, Alasanya karena Helper autocompleate hanya menerima 2 variabel sja ($kolom, $tabel) sedangkan pada modul ada kondisi yang harus dipenuhi.

Jika saya gunakan helper  autocompleate  pada kasus ini, maka data akan dimunculkan semua termasuk submodul. 

Mungkin helper  autocompleate  perlu diupdate dengan tambahan $kondisi;

Salah satu contoh, pada autocompleate menu menggunakan helper. saat melakukan pencarian semua data menu ditampilkan.