### PR TITLE
Perbaikan Insert Slug Pada Artikel / Kategori Tidak Bolek Sama

### DIFF
--- a/donjo-app/controllers/Web.php
+++ b/donjo-app/controllers/Web.php
@@ -136,7 +136,7 @@ class Web extends Admin_Controller {
 			redirect("web/index/$cat/$p/$o");
 
 		$this->web_artikel_model->update($cat, $id);
-		redirect("web/form/$cat/$p/$o/$id");
+		redirect("web/index/$cat");
 	}
 
 	public function delete($cat = 1, $p = 1, $o = 0, $id = '')

--- a/donjo-app/models/Web_artikel_model.php
+++ b/donjo-app/models/Web_artikel_model.php
@@ -157,8 +157,18 @@
 		}
 		// Batasi judul menggunakan teks polos
 		$data['judul'] = strip_tags($data['judul']);
+		
 		// Gunakan judul untuk url artikel
 		$slug = url_title($data['judul'], 'dash', TRUE);
+
+		//cek slug
+		$cek_slug = $this->db->where('slug', $slug)->get('artikel')->row_array();
+		if ($cek_slug)
+		{
+			$_SESSION['error_msg'].= " -> Slug tidak boleh sama";
+		  $_SESSION['success'] = -1;		  
+		  return;
+		}
 
 		$fp = time();
 		$list_gambar = array('gambar','gambar1','gambar2','gambar3');

--- a/donjo-app/models/Web_kategori_model.php
+++ b/donjo-app/models/Web_kategori_model.php
@@ -106,7 +106,18 @@ class Web_kategori_model extends CI_Model {
 		$data = $_POST;
 		$data['enabled'] = 1;
 		$data['urut'] = $this->urut_model->urut_max(array('parrent' => 0)) + 1;
-		$data['slug'] = url_title($this->input->post('kategori'), 'dash', TRUE);
+		$slug = url_title($this->input->post('kategori'), 'dash', TRUE);
+
+		//cek slug
+		$cek_slug = $this->db->where('slug', $slug)->get('kategori')->row_array();
+		if ($cek_slug)
+		{
+			$_SESSION['error_msg'].= " -> Slug tidak boleh sama";
+		  $_SESSION['success'] = -1;		  
+		  return;
+		}
+
+		$data['slug'] = $slug;
 		$outp = $this->db->insert('kategori', $data);
 		
 		pesan_sukses($outp); //Tampilkan Pesan


### PR DESCRIPTION
Hanya untuk solusi sementara perbaikan issue  #2809 
Sekalian ubah redirect setelah update menuju tabel artikel

Mungkin perlu dicarikan solusi yg lebih friendly agar tidak merefresh halaman sehingga menghapus data yg sudah diketik sebelumnya ketika terjadi error baik itu :
- error saat menyimpan data dgn isian kosong (isi artikel)
- slug yg sma
