### PR TITLE
Data Pemudik Saat Pandemi Covid-19 (terkait issue #2856)

### DIFF
--- a/donjo-app/controllers/Covid19.php
+++ b/donjo-app/controllers/Covid19.php
@@ -5,7 +5,8 @@ class Covid19 extends Admin_Controller {
 	public function __construct()
 	{
 		parent::__construct();
-		session_start();
+
+		$this->load->library('session');
 		$this->load->model('header_model');
 		$this->load->model('covid19_model');
 		$this->modul_ini = 206;
@@ -19,14 +20,13 @@ class Covid19 extends Admin_Controller {
 
 	public function data_pemudik($p = 1)
 	{
-		if (isset($_POST['per_page']))
-			$_SESSION['per_page'] = $_POST['per_page'];
+		if (isset($_POST['per_page'])) 
+			$this->session->set_userdata('per_page', $_POST['per_page']);
 		else 
-			$_SESSION['per_page'] = 10;
-
+			$this->session->set_userdata('per_page', 10);
 		
 		$data = $this->covid19_model->get_rincian_pemudik($p);
-		$data['per_page'] = $_SESSION['per_page'];
+		$data['per_page'] = $this->session->userdata('per_page');
 
 		$nav['act'] = 206;
 		$header = $this->header_model->get_data();
@@ -93,7 +93,7 @@ class Covid19 extends Admin_Controller {
 		$this->load->view('header', $header);
 		$this->load->view('nav', $nav);
 		$data['terdata'] = $this->covid19_model->get_detil_pemudik_by_id($id);
-		$data['individu'] = $this->covid19_model->get_terdata($data['terdata']['id_terdata']);
+		$data['individu'] = $this->covid19_model->get_pemudik($data['terdata']['id_terdata']);
 
 		$data['terdata']['judul_terdata_nama'] = 'NIK';
 		$data['terdata']['judul_terdata_info'] = 'Nama Terdata';
@@ -109,10 +109,10 @@ class Covid19 extends Admin_Controller {
 		/*
 		 * Print xls untuk data x
 		 * */
-		$_SESSION['per_page'] = 0; // Unduh semua data
+		$this->session->set_userdata('per_page', 0); // Unduh semua data
 		$data = $this->covid19_model->get_rincian_pemudik(1);
 		$data['desa'] = $this->header_model->get_data();
-		$_SESSION['per_page'] = 10; // Kembalikan ke paginasi default
+		$this->session->set_userdata('per_page', 10); // Kembalikan ke paginasi default
 
 		$this->load->view('covid19/unduh-sheet', $data);
 	}

--- a/donjo-app/controllers/Covid19.php
+++ b/donjo-app/controllers/Covid19.php
@@ -75,7 +75,7 @@ class Covid19 extends Admin_Controller {
 
 	public function edit_pemudik_form($id = 0)
 	{
-		$data = $this->covid19_model->get_pemudik_by_id($id);		
+		$data = $this->covid19_model->get_pemudik_by_id($id);	
 		$data['form_action'] = site_url("covid19/edit_pemudik/$id");
 		$this->load->view('covid19/edit_pemudik', $data);
 	}

--- a/donjo-app/models/Covid19_model.php
+++ b/donjo-app/models/Covid19_model.php
@@ -209,6 +209,7 @@
 			'tujuan_mudik' => $tujuan,
 			'no_hp' => $post['hp_pemudik'],
 			'email' => $post['email_pemudik'],
+			'status_covid' => $post['status_covid'],
 			'keluhan_kesehatan' => $post['keluhan'],
 			'keterangan' => $post['keterangan']
 		);
@@ -225,7 +226,7 @@
 	{
 		$data = $this->db->where('id', $id)->get('covid19_pemudik')->row_array();
 		// Data tambahan untuk ditampilkan
-		$terdata = $this->get_terdata($data['id_terdata']);
+		$terdata = $this->get_pemudik($data['id_terdata']);
 		$data['judul_terdata_nama'] = 'NIK';
 		$data['judul_terdata_info'] = 'Nama Terdata';
 		$data['terdata_nama'] = $terdata['nik'];
@@ -260,6 +261,7 @@
 			'tujuan_mudik' => $tujuan,
 			'no_hp' => $post['hp_pemudik'],
 			'email' => $post['email_pemudik'],
+			'status_covid' => $post['status_covid'],
 			'keluhan_kesehatan' => $post['keluhan'],
 			'keterangan' => $post['keterangan']
 		);

--- a/donjo-app/models/Covid19_model.php
+++ b/donjo-app/models/Covid19_model.php
@@ -41,6 +41,8 @@
 		$this->db->select('o.nama');
 		$this->db->select('o.tempatlahir');
 		$this->db->select('o.tanggallahir');
+		$this->db->select("(select (date_format(from_days((to_days(now()) - to_days(tweb_penduduk.tanggallahir))),'%Y') + 0) AS `(date_format(from_days((to_days(now()) - to_days(tweb_penduduk.tanggallahir))),'%Y') + 0)`
+		from tweb_penduduk where (tweb_penduduk.id = o.id)) AS umur");
 		$this->db->select('o.sex');
 		$this->db->select('w.rt');
 		$this->db->select('w.rw');

--- a/donjo-app/models/migrations/Migrasi_2004_ke_2005.php
+++ b/donjo-app/models/migrations/Migrasi_2004_ke_2005.php
@@ -105,6 +105,11 @@ class Migrasi_2004_ke_2005 extends CI_model {
 					'constraint' => 255,
 					'null' => TRUE,
 				),
+				'status_covid' => array(
+					'type' => 'VARCHAR',
+					'constraint' => 50,
+					'null' => TRUE,
+				),
 				'no_hp' => array(
 					'type' => 'VARCHAR',
 					'constraint' => 20,

--- a/donjo-app/views/covid19/data_pemudik.php
+++ b/donjo-app/views/covid19/data_pemudik.php
@@ -55,12 +55,14 @@
 																<th>Aksi</th>
 																<th>NIK</th>
 																<th>Nama</th>
-																<th>Tanggal Lahir</th>
+																<th>Usia</th>
 																<th>JK</th>
 																<th>Alamat</th>
 																<th>Asal Pemudik</th>
 																<th>Tanggal Tiba</th>
 																<th>Tujuan Pemudik</th>
+																<th>Kontak</th>
+																<th>Status</th>
 																<th>Keluhan</th>
 															</tr>
 														</thead>
@@ -81,7 +83,7 @@
 																	</td>
 																	<td><?= $item["terdata_nama"] ?></td>
 																	<td nowrap><a href="<?= site_url('covid19/detil_pemudik/'.$item["id"])?>" title="Data terdata"><?= $item['terdata_info'];?></a></td>
-																	<td><?= $item["tanggal_lahir"] ?></td>
+																	<td><?= $item["umur"] ?></td>
 																	<?php
 																	$jk = (strtoupper($item['sex']) === "PEREMPUAN") ? "Pr" : "Lk"; 
 																	?>
@@ -90,6 +92,8 @@
 																	<td><?= $item["asal_mudik"];?></td>
 																	<td><?= $item["tanggal_datang"];?></td>
 																	<td><?= $item["tujuan_mudik"];?></td>
+																	<td><?= $item["no_hp"];?> - <?= $item["email"];?> </td>
+																	<td><?= $item["status_covid"];?></td>
 																	<td><?= $item["keluhan_kesehatan"];?></td>
 																</tr>
 																	<?php

--- a/donjo-app/views/covid19/detil_pemudik.php
+++ b/donjo-app/views/covid19/detil_pemudik.php
@@ -75,6 +75,10 @@
                     <td> <?= $terdata["email"]?></td>
                   </tr>
                   <tr>
+                    <td style="padding-top : 10px;padding-bottom : 10px;" >Status Covid-19</td>
+                    <td> <?= $terdata["status_covid"]?></td>
+                  </tr>
+                  <tr>
                     <td style="padding-top : 10px;padding-bottom : 10px;" >Keluhan Kesehatan</td>
                     <td> <?= $terdata["keluhan_kesehatan"]?></td>
                   </tr>

--- a/donjo-app/views/covid19/form_isian_pemudik.php
+++ b/donjo-app/views/covid19/form_isian_pemudik.php
@@ -34,7 +34,7 @@
 			<option <?= $selected?> value="1">Liburan</option>
 
 			<?php if($tujuan_mudik === "Menjenguk Keluarga"): $selected = "selected"; else:  $selected = ""; endif ?>
-			<option <?= $selected?> <?= $selected?> value="2">Menjenguk Keluarga</option>
+			<option <?= $selected?> value="2">Menjenguk Keluarga</option>
 
 			<?php if($tujuan_mudik === "Pulang Kampung"): $selected = "selected"; else:  $selected = ""; endif ?>
 			<option <?= $selected?> value="3">Pulang Kampung</option>
@@ -56,6 +56,34 @@
 	<div class="col-sm-4">
 		<input class="form-control input-sm" type="text" name="email_pemudik" id="email_pemudik" value="<?= $email?>" placeholder="Email">
 	</div>
+</div>
+
+<div class="form-group">
+	<label  class="col-sm-3 control-label" for="status_covid">Status Covid-19</label>
+	<div class="col-sm-8">
+		<select class="form-control input-sm" name="status_covid" id="status_covid">
+			<?php if($status_covid === ""): $selected = "selected"; else:  $selected = ""; endif ?>
+			<option <?= $selected?> value="" >-- Pilih Status Covid-19 --</option>
+
+			<?php if($status_covid === "ODP"): $selected = "selected"; else:  $selected = ""; endif ?>
+			<option <?= $selected?> value="ODP">Orang Dalam Pemantauan (ODP)</option>
+
+			<?php if($status_covid === "PDP"): $selected = "selected"; else:  $selected = ""; endif ?>
+			<option <?= $selected?> value="PDP">Pasien Dalam Pengawasan (PDP)</option>
+
+			<?php if($status_covid === "ODR"): $selected = "selected"; else:  $selected = ""; endif ?>
+			<option <?= $selected?> value="ODR">Orang Dalam Resiko (ODR)</option>
+
+			<?php if($status_covid === "OTG"): $selected = "selected"; else:  $selected = ""; endif ?>
+			<option <?= $selected?> value="OTG">Orang Tanpa Gejala (OTG)</option>
+
+			<?php if($status_covid === "POSITIF"): $selected = "selected"; else:  $selected = ""; endif ?>
+			<option <?= $selected?> value="POSITIF">Positif</option>
+
+			<?php if($status_covid === "DLL"): $selected = "selected"; else:  $selected = ""; endif ?>
+			<option <?= $selected?> value="DLL">Dan Lain Lain</option>
+		</select>
+	 </div>
 </div>
 
 <div class="form-group">

--- a/donjo-app/views/covid19/unduh-sheet.php
+++ b/donjo-app/views/covid19/unduh-sheet.php
@@ -45,6 +45,7 @@
 							<th>Durasi Mudik</th>
 							<th>No HP</th>
 							<th>Email</th>
+							<th>Status Covid-19</th>
 							<th>Keluhan Kesehatan</th>
 							<th>Keterangan</th>
 						</tr>
@@ -65,6 +66,7 @@
 								<td><?= $item["durasi_mudik"]?></td>
 								<td><?= $item["no_hp"]?></td>
 								<td><?= $item["email"]?></td>
+								<td><?= $item["status_covid"]?></td>
 								<td><?= $item["keluhan_kesehatan"]?></td>
 								<td><?= $item["keterangan"]?></td>
 							</tr>


### PR DESCRIPTION
Solusi untuk fitur baru "Data Pemudik Saat Pandemi Covid-19" terkait issue #2856
Apa yang baru:

1. Menambahkan Menu "Siaga Covid-19" di tabel setting_modul -> sementara menggunakan urutan menu 0, bisa diatur kembali

2. Menambahkan tabel baru "covid19_pemudik" untuk mencatat data pemudik dengan field-field sebagai berikut: (asal pemudik, tanggal tiba, tujuan pemudik, durasi pemudik, no hp, email, keluhan kesehatan, dan keterangan) -> menggunakan flow seperti data supplemen, rencana ke dapan akan memasukkan tabel ini ke tabel supplemen (dengan perubahan modul suplemen menjadi lebih dinamis untuk penambahan informasi field yang dibutuhkan)

3. CRUD Data pemudik dan unduhsheet



