### PR TITLE
Show/Hide RSS Feed Covid19 melalui setting di desa/config/config.php

### DIFF
--- a/desa-contoh/config/config.php
+++ b/desa-contoh/config/config.php
@@ -20,7 +20,7 @@
 // dapat membuat artikel berisi video yang aktif ditampilkan di Web.
 // Misalnya, ganti dengan id = 1 jika ingin membuat pengguna admin sebagai pengguna terpecaya.
 	$config['user_admin'] = 0;
-	
+
 /*
 	Setting untuk tampilkan data Covid-19. Untuk menyembunyikan ganti menjadi nilai 0;
 	Untuk menampilkan data provinsi, gunakan setting 'provinsi_covid'.
@@ -28,5 +28,12 @@
 */
 	$config['covid_data'] = 1;
 	$config['provinsi_covid'] = 51; // kode provinsi. Comment baris ini untuk menampilkan data Indonesia
-	$config['covid_desa'] = 1; // Tampilkan status COVID-19 dari data OpenSID desa
-	
+	$config['covid_desa'] = 1; // Tampilkan status COVID-19 dari data OpenSID desa di Halaman Muka
+	$config['covid_peta'] = 1; // Tampilkan status COVID-19 di di Halaman Peta
+	$config['covid_rss'] = 0; // Tampilkan rss feed https://www.covid19.go.id/feed/ di Halaman Muka
+
+/*
+	Setting untuk tampilkan grafik APBDes di Footer Halaman Muka atau Semua Halaman web. Untuk menyembunyikan ganti menjadi nilai 0;
+*/
+	$config['apbdes_footer'] = 1; // Tampilkan grafik APBDes di Halaman Muka Saja
+	$config['apbdes_footer_all'] = 0; // Tampilkan grafik APBDes di Semua Halaman

--- a/donjo-app/controllers/First.php
+++ b/donjo-app/controllers/First.php
@@ -92,12 +92,19 @@ class First extends Web_Controller {
 		$data['artikel'] = $this->first_artikel_m->artikel_show($data['paging']->offset, $data['paging']->per_page);
 
 		$data['headline'] = $this->first_artikel_m->get_headline();
+		if (config_item('covid_rss'))
+		{
 		$data['feed'] = array(
 			'items' => $this->first_artikel_m->get_feed(),
 			'title' => 'BERITA COVID19.GO.ID',
-			'url' => 'https://www.covid19.go.id'
-		);
+			'url' => 'https://covid19.go.id/feed/');
+		}
+
+		if (config_item('apbdes_footer'))
+		{
 		$data['transparansi'] = $this->keuangan_grafik_model->grafik_keuangan_tema();
+		}
+
 		$data['covid'] = $this->laporan_penduduk_model->list_data('covid');
 
 		$cari = trim($this->input->get('cari'));
@@ -240,7 +247,7 @@ class First extends Web_Controller {
 		{
 			$data['kk'] = $this->keluarga_model->list_anggota($data['penduduk']['id_kk']);
 		}
-		
+
 		$this->load->view('web/mandiri/layout.mandiri.php', $data);
 	}
 
@@ -599,6 +606,10 @@ class First extends Web_Controller {
 		$this->web_widget_model->get_widget_data($data);
 		$data['data_config'] = $this->config_model->get_data();
 		$data['flash_message'] = $this->session->flashdata('flash_message');
+		if (config_item('apbdes_footer') AND config_item('apbdes_footer_all'))
+		{
+		$data['transparansi'] = $this->keuangan_grafik_model->grafik_keuangan_tema();
+		}
 		// Pembersihan tidak dilakukan global, karena artikel yang dibuat oleh
 		// petugas terpecaya diperbolehkan menampilkan <iframe> dsbnya..
 		$list_kolom = array(
@@ -741,7 +752,7 @@ class First extends Web_Controller {
 		$data = $this->web_dokumen_model->get_dokumen($id_dokumen, $this->session->userdata('id'));
 
 		$data['anggota'] = $this->web_dokumen_model->get_dokumen_di_anggota_lain($id_dokumen);
-		
+
 		if (empty($data))
 		{
 			$data['success'] = -1;


### PR DESCRIPTION
Respon server rss feed https://www.covid19.go.id/feed/ semakin membutuhkan waktu yg lama karena semakin banyaknya pengguna yg mengakses yg akibatnya memperlambat loading halaman muka desa, maka ada opsi pilihan untuk menampilkan/menyembunyikan RSS Feed Covid19 melalui setting di desa/config/config.php.
`$config['covid_rss'] = 0;`