### PR TITLE
Update Statistik.php

### DIFF
--- a/donjo-app/controllers/Statistik.php
+++ b/donjo-app/controllers/Statistik.php
@@ -126,7 +126,7 @@ class Statistik extends Admin_Controller {
 		$this->load->view('statistik/penduduk_pie', $data);
 		if (in_array($lap, array('bantuan_keluarga', 'bantuan_penduduk')))
 		{
-			$this->load->view('statistik/peserta_bantuan', $data)
+			$this->load->view('statistik/peserta_bantuan', $data);
 		}
 		$this->load->view('footer');
 	}


### PR DESCRIPTION
Ada kekurangan penulisan/pengetikan titik koma (;) pada baris 129, yang menyebabkan error 500 ketika kita klik menu bantuan di dashboard-home. (sudah dicoba di demo, juga sama)
![image](https://user-images.githubusercontent.com/45786885/82223622-14e05880-994d-11ea-87d5-b89279e5a11a.png)
======
errornya di : 
![image](https://user-images.githubusercontent.com/45786885/82223744-42c59d00-994d-11ea-9e59-a542bb4f11ed.png)



