### PR TITLE
Perbaiki error reinitialise DataTable

### DIFF
--- a/donjo-app/controllers/Statistik.php
+++ b/donjo-app/controllers/Statistik.php
@@ -124,9 +124,6 @@ class Statistik extends Admin_Controller {
 		$this->load->view('header', $header);
 		$this->load->view('nav', $nav);
 		$this->load->view('statistik/penduduk_pie', $data);
-		if (in_array($lap, array('bantuan_keluarga', 'bantuan_penduduk')))
-			$this->load->view('statistik/peserta_bantuan', $data);
-
 		$this->load->view('footer');
 	}
 


### PR DESCRIPTION
Warning error reinitialise DataTable akan muncul keika klik button Pie Data, karena DataTable sudah di load di script penduduk_pie.php
