### PR TITLE
tabel ref_status_covid masuk ke daftar tabel yang tidak boleh dikosongkan

### DIFF
--- a/donjo-app/models/Database_model.php
+++ b/donjo-app/models/Database_model.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 class Database_model extends CI_Model {
 
@@ -106,7 +106,7 @@ class Database_model extends CI_Model {
 				if (function_exists(__NAMESPACE__ .'\Database_model::'.$migrate))
 					call_user_func(__NAMESPACE__ .'\Database_model::'.$migrate);
 				else
-					$this->jalankan_migrasi($migrate);					
+					$this->jalankan_migrasi($migrate);
 			}
 		}
 		else
@@ -3614,6 +3614,7 @@ class Database_model extends CI_Model {
 			"ref_dokumen",
 			"ref_pindah",
 			"ref_syarat_surat",
+			"ref_status_covid",
 			"setting_modul",
 			"setting_aplikasi",
 			"setting_aplikasi_options",

--- a/donjo-app/models/migrations/Migrasi_2005_ke_2006.php
+++ b/donjo-app/models/migrations/Migrasi_2005_ke_2006.php
@@ -4,6 +4,7 @@ class Migrasi_2005_ke_2006 extends CI_model {
 	public function up()
 	{
 		$this->grup_akses_covid19();
+		$this->bug_fix_ref_status_covid19(); // untuk yang sudah terlanjur mengkosongkan DB sebelum PR ini disetujui
 
 		// Ubah nama kode status penduduk
 		$this->db->where('id', 2)
@@ -50,6 +51,44 @@ class Migrasi_2005_ke_2006 extends CI_model {
 		foreach ($data as $grup)
 		{
 			$sql = $this->db->insert_string('user_grup', $grup);
+			$sql .= " ON DUPLICATE KEY UPDATE
+			id = VALUES(id),
+			nama = VALUES(nama)";
+			$this->db->query($sql);
+		}
+	}
+
+	private function bug_fix_ref_status_covid19()
+	{
+		// Tambah Data di Tabel ref_status_covid
+		$data = array();
+		$data[] = array(
+			'id'=>'1',
+			'nama' => 'ODP');
+
+		$data[] = array(
+			'id'=>'2',
+			'nama' => 'PDP');
+
+		$data[] = array(
+			'id'=>'3',
+			'nama' => 'ODR');
+
+		$data[] = array(
+			'id'=>'4',
+			'nama' => 'OTG');
+
+		$data[] = array(
+			'id'=>'5',
+			'nama' => 'POSITIF');
+
+		$data[] = array(
+			'id'=>'6',
+			'nama' => 'DLL');
+
+		foreach ($data as $status)
+		{
+			$sql = $this->db->insert_string('ref_status_covid', $status);
 			$sql .= " ON DUPLICATE KEY UPDATE
 			id = VALUES(id),
 			nama = VALUES(nama)";


### PR DESCRIPTION
Solusi untuk perbaikan terkait issue:

Saat pengguna menggunakan fitur kosongkan DB, tabel ref_status_covid juga ikut dikosongkan, sehingga mengakibatkan query data untuk agregat statistik status covid tidak berjalan semestinya.

![screenshot-localhost-2020 05 19-06_01_55](https://user-images.githubusercontent.com/13193883/82293349-9e883880-99d6-11ea-9c93-ccc5015a7e5d.png)


