### PR TITLE
Opsi Config Tampilkan / Tidak Tampilkan Daftar Peserta Bantuan

### DIFF
--- a/desa-contoh/config/config.php
+++ b/desa-contoh/config/config.php
@@ -26,13 +26,18 @@
 	Untuk menampilkan data provinsi, gunakan setting 'provinsi_covid'.
 	Kode provinsi sesuai dengan yg di http://pusatkrisis.kemkes.go.id/daftar-kode-provinsi
 */
-	$config['covid_data'] = 1;
+	$config['covid_data'] = 0;
 	$config['provinsi_covid'] = 51; // kode provinsi. Comment baris ini untuk menampilkan data Indonesia
 	$config['covid_desa'] = 1; // Tampilkan status Covid-19 dari data OpenSID desa
-	$config['covid_rss'] = 1; // Tampilkan rss feed https://www.covid19.go.id/feed/ di halaman muka
+	$config['covid_rss'] = 0; // Tampilkan rss feed https://www.covid19.go.id/feed/ di halaman muka
 
 /*
 	Setting untuk tampilkan grafik APBDes di Footer Halaman Muka atau Semua Halaman web. Untuk menyembunyikan ganti menjadi nilai 0;
 */
 	$config['apbdes_footer'] = 1; // Tampilkan grafik APBDes di halaman muka saja
-	$config['apbdes_footer_all'] = 0; // Tampilkan grafik APBDes di semua halaman
+	$config['apbdes_footer_all'] = 1; // Tampilkan grafik APBDes di semua halaman
+
+/*
+	Setting untuk tampilkan daftar penerima bantuan statistik halaman web. Untuk menyembunyikan ganti menjadi nilai 0;
+*/
+	$config['daftar_bantuan'] = 0;

--- a/desa-contoh/config/config.php
+++ b/desa-contoh/config/config.php
@@ -26,10 +26,10 @@
 	Untuk menampilkan data provinsi, gunakan setting 'provinsi_covid'.
 	Kode provinsi sesuai dengan yg di http://pusatkrisis.kemkes.go.id/daftar-kode-provinsi
 */
-	$config['covid_data'] = 0;
+	$config['covid_data'] = 1;
 	$config['provinsi_covid'] = 51; // kode provinsi. Comment baris ini untuk menampilkan data Indonesia
 	$config['covid_desa'] = 1; // Tampilkan status Covid-19 dari data OpenSID desa
-	$config['covid_rss'] = 0; // Tampilkan rss feed https://www.covid19.go.id/feed/ di halaman muka
+	$config['covid_rss'] = 1; // Tampilkan rss feed https://www.covid19.go.id/feed/ di halaman muka
 
 /*
 	Setting untuk tampilkan grafik APBDes di Footer Halaman Muka atau Semua Halaman web. Untuk menyembunyikan ganti menjadi nilai 0;
@@ -40,4 +40,4 @@
 /*
 	Setting untuk tampilkan daftar penerima bantuan statistik halaman web. Untuk menyembunyikan ganti menjadi nilai 0;
 */
-	$config['daftar_bantuan'] = 0;
+	$config['daftar_bantuan'] = 1;

--- a/themes/klasik/layouts/stat.tpl.php
+++ b/themes/klasik/layouts/stat.tpl.php
@@ -12,7 +12,9 @@
 						<?php else: ?>
 							<?php $this->load->view('statistik/penduduk_grafik.php'); ?>
 							<?php if (in_array($st, array('bantuan_keluarga', 'bantuan_penduduk'))):?>
-								<?php $this->load->view('statistik/peserta_bantuan', array('lap' => $st)); ?>
+								<?php if (config_item('daftar_bantuan')):?>
+									<?php $this->load->view('statistik/peserta_bantuan', array('lap' => $st)); ?>
+								<?php endif;?>
 							<?php endif;?>
 						<?php endif; ?>
 					</div>


### PR DESCRIPTION
Tampilkan / Tidak Tampilkan daftar peserta bantuan sasaran penduduk dan keluarga di Web. #3095

1. Sementara config di atur di desa/config/config.php 
$config['daftar_bantuan'] = 1; 

2. Untuk Tema Klasik dan Hadakewa, tema lain disesuaikan di file /partials/statistik.php

