### PR TITLE
Opsi tampilkan Nama Peserta (bukan nama Kepala Keluarga) di daftar penerima bantuan

### DIFF
--- a/donjo-app/controllers/First.php
+++ b/donjo-app/controllers/First.php
@@ -95,7 +95,7 @@ class First extends Web_Controller {
 		$data['artikel'] = $this->first_artikel_m->artikel_show($data['paging']->offset, $data['paging']->per_page);
 
 		$data['headline'] = $this->first_artikel_m->get_headline();
-		if (config_item('covid_rss'))
+		if ($this->setting->covid_rss)
 		{
 			$data['feed'] = array(
 				'items' => $this->first_artikel_m->get_feed(),
@@ -104,7 +104,7 @@ class First extends Web_Controller {
 			);
 		}
 
-		if (config_item('apbdes_footer'))
+		if ($this->setting->apbdes_footer)
 		{
 			$data['transparansi'] = $this->keuangan_grafik_model->grafik_keuangan_tema();
 		}
@@ -397,15 +397,30 @@ class First extends Web_Controller {
 		$data = array();
 		$no = $_POST['start'];
 
-		foreach ($peserta as $baris)
+		if ($this->setting->daftar_bantuan_nama)
 		{
-			$no++;
-			$row = array();
-			$row[] = $no;
-			$row[] = $baris['program'];
-			$row[] = $baris['peserta'];
-			$row[] = $baris['alamat'];
-			$data[] = $row;
+			foreach ($peserta as $baris)
+			{
+				$no++;
+				$row = array();
+				$row[] = $no;
+				$row[] = $baris['program'];
+				$row[] = $baris['peserta_nama'];
+				$row[] = $baris['alamat'];
+				$data[] = $row;
+			}
+		}
+		else {
+			foreach ($peserta as $baris)
+			{
+				$no++;
+				$row = array();
+				$row[] = $no;
+				$row[] = $baris['program'];
+				$row[] = $baris['peserta'];
+				$row[] = $baris['alamat'];
+				$data[] = $row;
+			}
 		}
 
 		$output = array(
@@ -625,7 +640,7 @@ class First extends Web_Controller {
 		$this->web_widget_model->get_widget_data($data);
 		$data['data_config'] = $this->config_model->get_data();
 		$data['flash_message'] = $this->session->flashdata('flash_message');
-		if (config_item('apbdes_footer') AND config_item('apbdes_footer_all'))
+		if ($this->setting->apbdes_footer AND $this->setting->apbdes_footer_all)
 		{
 			$data['transparansi'] = $this->keuangan_grafik_model->grafik_keuangan_tema();
 		}

--- a/donjo-app/models/Program_bantuan_model.php
+++ b/donjo-app/models/Program_bantuan_model.php
@@ -979,7 +979,7 @@ class Program_bantuan_model extends CI_Model {
 	private function get_all_peserta_bantuan_query()
 	{
 		$this->db
-			->select("p.nama as program, pend.nama as peserta, concat('RT ', w.rt, ' / RW ', w.rw, ' DUSUN ', w.dusun) AS alamat")
+			->select("p.nama as program, pend.nama as peserta, pp.kartu_nama as peserta_nama, concat('RT ', w.rt, ' / RW ', w.rw, ' DUSUN ', w.dusun) AS alamat")
 			->from('program p')
 			->join('program_peserta pp', 'p.id = pp.program_id', 'left');
 		if ($this->input->post('stat') == 'bantuan_keluarga')


### PR DESCRIPTION
Saat ini untuk daftar penerima bantuan sasaran keluarga, Nama peserta yg ditampilkan adalah Nama Kepala Keluarga. Jika ada penerima bantuan keluarga yg ditujukan kepada anggota keluarga misalnya Istri sebagai nama kartu peserta, maka nama yg tercantum di daftar tidak akan sama dengan Nama Penerima bantuan yg sebenarnya. 
Untuk ini ada Opsi untuk memilih untuk tampilkan Nama Kepala Keluarga atau Nama Kartu Peserta di daftar penerima bantuan.

NAMA KEPALA KELUARGA
![nama_kepala_keluarga](https://user-images.githubusercontent.com/10391199/83863593-b9380c80-a74d-11ea-912b-6e1e79ae885d.PNG)

NAMA KARTU PESERTA
![nama_kartu_peserta](https://user-images.githubusercontent.com/10391199/83863600-bb9a6680-a74d-11ea-91d2-abe428dc7806.PNG)

KONFIGURASI (berhubungan dengan PR #3147)
![bantuan_nama](https://user-images.githubusercontent.com/10391199/83863637-cd7c0980-a74d-11ea-80a8-6429cc002d96.PNG)




