### PR TITLE
Nama Peserta di Kartu Peserta Bantuan dapat dipilih secara Dinamis

### DIFF
--- a/donjo-app/controllers/Program_bantuan.php
+++ b/donjo-app/controllers/Program_bantuan.php
@@ -10,6 +10,8 @@ class Program_bantuan extends Admin_Controller {
 		$this->load->model('header_model');
 		$this->load->model('program_bantuan_model');
 		$this->load->model('config_model');
+		$this->load->model('keluarga_model');
+		$this->load->model('penduduk_model');
 		$this->modul_ini = 6;
 		$this->set_page = ['20', '50', '100'];
 	}
@@ -54,13 +56,16 @@ class Program_bantuan extends Admin_Controller {
 		$data['program'] = $this->program_bantuan_model->get_program(1, $program_id);
 		$sasaran = $data['program'][0]['sasaran'];
 		$nik = $this->input->post('nik');
+		$id = $this->input->post('id_kk');
 		if (isset($nik))
 		{
 			$data['individu'] = $this->program_bantuan_model->get_peserta($nik, $sasaran);
+			$data['kartu_peserta'] = $this->keluarga_model->list_anggota($id);
 		}
 		else
 		{
 			$data['individu'] = NULL;
+			$data['kartu_peserta'] = NULL;
 		}
 		$data['form_action'] = site_url("program_bantuan/add_peserta/".$program_id);
 		$header = $this->header_model->get_data();

--- a/donjo-app/views/program_bantuan/form.php
+++ b/donjo-app/views/program_bantuan/form.php
@@ -56,101 +56,141 @@
 										<div class="box-header with-border">
 											<h3 class="box-title">Tambah Peserta Program</h3>
 										</div>
-                     <div class="box-body">
-                       <form action="" id="main" name="main" method="POST"  class="form-horizontal">
+										<div class="box-body">
+											<form action="" id="main" name="main" method="POST" class="form-horizontal">
 												<div class="form-group" >
-									  			<label class="col-sm-4 col-lg-2 control-label <?php ($detail['sasaran'] != 1) and print('no-padding-top') ?>" for="nik"><?= $detail['judul_cari_peserta']?></label>
+													<label class="col-sm-4 col-lg-2 control-label <?php ($detail['sasaran'] != 1) and print('no-padding-top') ?>" for="nik"><?= $detail['judul_cari_peserta']?></label>
 													<div class="col-sm-7">
 														<select class="form-control select2 input-sm" id="nik" name="nik"  onchange="formAction('main')" style="width:100%" >
 															<option selected="selected">-- Silakan Masukan <?= $detail['judul_cari_peserta']?> --</option>
 															<?php foreach ($program[2]as $item):
-										  					if (strlen($item["id"])>0): ?>
-											  				  <option value="<?= $item['id']?>" <?php if ($individu['nik']==$item['nik']): ?>selected<?php endif; ?>>Nama : <?= $item['nama']." - ".$item['info']?></option>
+																if (strlen($item["id"])>0): ?>
+																<option value="<?= $item['id']?>" <?php if ($individu['nik']==$item['nik']): ?>selected<?php endif; ?>>Nama : <?= $item['nama']." - ".$item['info']?></option>
 																<?php endif;
-                              endforeach;?>
-  													</select>
-													</div>
-					    					</div>
-                        <?php if ($individu): ?>
-                          <?php include("donjo-app/views/program_bantuan/konfirmasi_peserta.php"); ?>
-                        <?php endif; ?>
-                      </form>
-                      <form id="validasi" action="<?= $form_action?>/<?= $detail['id']?>" method="POST" enctype="multipart/form-data" class="form-horizontal">
-												<input type="hidden" name="nik" value="<?= $individu['nik']?>"  >
-												<div class="form-group">
-													<label for="kartu_nik" class="col-sm-11 control-label text-left">IDENTITAS PADA KARTU PESERTA</label>
-												</div>
-												<div class="form-group">
-													<label for="no_id_kartu" class="col-sm-4 col-lg-2  control-label">Nomor Kartu Peserta</label>
-													<div class="col-sm-7">
-								  					<input  id="no_id_kartu" class="form-control input-sm required" type="text" placeholder="Nomor Kartu Peserta" name="no_id_kartu" >
+															endforeach;?>
+														</select>
 													</div>
 												</div>
-												<div class="form-group">
-													<label for="jenis_keramaian"  class="col-sm-4 col-lg-2 control-label">Gambar Kartu Peserta</label>
-													<div class="col-sm-7">
-														<div class="input-group input-group-sm ">
-															<input type="text" class="form-control" id="file_path">
-															<input type="file" class="hidden" id="file" name="satuan">
-															<span class="input-group-btn">
-																<button type="button" class="btn btn-info btn-flat"  id="file_browser"><i class="fa fa-search"></i> Browse</button>
-															</span>
-														</div>
-														<p class="help-block text-red">Kosongkan jika tidak ingin mengunggah gambar.</p>
-													</div>
-												</div>
-												<div class="form-group">
-													<label for="kartu_nik"  class="col-sm-4 col-lg-2 control-label">NIK</label>
-													<div class="col-sm-7">
-														<input id="kartu_nik" class="form-control input-sm" type="text" placeholder="Nomor NIK Peserta" name="kartu_nik"  value="<?= $individu['nik_peserta']?>">
-													</div>
-												</div>
-												<div class="form-group">
-													<label for="kartu_nama"  class="col-sm-4 col-lg-2 control-label">Nama</label>
-													<div class="col-sm-7">
-														<input id="kartu_nama" class="form-control input-sm" type="text" placeholder="Nama Peserta" name="kartu_nama"  value="<?= $individu['nama']?>">
-													</div>
-												</div>
-												<div class="form-group">
-													<label for="kartu_tempat_lahir"  class="col-sm-4 col-lg-2 control-label">Tempat Lahir</label>
-													<div class="col-sm-7">
-													<input id="kartu_tempat_lahir" class="form-control input-sm" type="text" placeholder="Tempat Lahir" name="kartu_tempat_lahir"  value="<?= $individu['tempatlahir']?>">
 
+												<?php if ($individu): ?>
+													<?php include("donjo-app/views/program_bantuan/konfirmasi_peserta.php"); ?>
+													<input type="hidden" id="id_kk" name="id_kk" value="<?= $individu['id_kk']?>">
+
+													<div class="form-group">
+														<label for="kartu_nik" class="col-sm-11 control-label text-left">IDENTITAS PADA KARTU PESERTA</label>
 													</div>
-												</div>
-												<div class="form-group">
-										  		<label for="kartu_tanggal_lahir"  class="col-sm-4 col-lg-2 control-label">Tanggal Lahir</label>
-													<div class="col-sm-7">
-														<div class="input-group input-group-sm date">
-															<div class="input-group-addon">
-																<i class="fa fa-calendar"></i>
-															</div>
-															<input class="form-control input-sm pull-right" id="tgl_1" name="kartu_tanggal_lahir" placeholder="Tgl. Lahir" type="text" value="<?= tgl_indo_out($individu['tanggallahir'])?>">
+
+													<div class="form-group" >
+														<label class="col-sm-4 col-lg-2 control-label"></label>
+														<div class="col-sm-7">
+															<button class="btn btn-social btn-flat btn-info btn-sm" id="btn_cari"><i class='fa fa-search'></i>Pilih Peserta</button>
 														</div>
 													</div>
-												</div>
-												<div class="form-group">
-													<label for="kartu_alamat"  class="col-sm-4 col-lg-2 control-label">Alamat</label>
-													<div class="col-sm-7">
-											  		<input  id="kartu_alamat" class="form-control input-sm" type="text" placeholder="Alamat" name="kartu_alamat" value="<?= $individu['alamat_wilayah'];?>">
+
+													<div class="form-group">
+														<label class="col-sm-4 col-lg-2 control-label" for="nik">Nama Peserta</label>
+														<div class="col-sm-7">
+															<select class="form-control select2 input-sm" id="peserta" name="peserta" style="width:100%" >
+																<option disabled selected>Pilih Nama Peserta...</option>
+																<?php foreach ($kartu_peserta as $item): ?>
+																	<option value="<?= $item['id']?>"
+																		data-nama="<?= strtoupper($item['nama'])?>"
+																		data-nik="<?= $item['nik']?>"
+																		data-tempatlahir="<?= $item['tempatlahir']?>"
+																		data-tanggallahir="<?= tgl_indo_out($item['tanggallahir'])?>"
+																		data-hubungan="<?= $item['hubungan']?>"
+																		><?= $item['nama']." - ".$item['nik']." - ".$item['hubungan']?></option>
+																	<?php endforeach;?>
+																</select>
+															</div>
+														</div>
+
+													<?php endif; ?>
+												</form>
+
+												<form id="validasi" action="<?= $form_action?>/<?= $detail['id']?>" method="POST" enctype="multipart/form-data" class="form-horizontal">
+													<input type="hidden" name="nik" value="<?= $individu['nik']?>"  >
+													<input type="hidden" id="kartu_nama" name="kartu_nama"  value="">
+													<div class="form-group">
+														<label for="kartu_nik"  class="col-sm-4 col-lg-2 control-label">NIK</label>
+														<div class="col-sm-7">
+															<input id="kartu_nik" class="form-control input-sm" type="text" placeholder="Nomor NIK Peserta" name="kartu_nik"  value="">
+														</div>
 													</div>
-												</div>
-												<div class="box-footer">
-													<div class="col-xs-12">
-												  	<button type="reset" class="btn btn-social btn-flat btn-danger btn-sm"><i class="fa fa-times"></i> Batal</button>
-														<button type="submit" class="btn btn-social btn-flat btn-info btn-sm pull-right"><i class="fa fa-check"></i> Simpan</button>
+													<div class="form-group">
+														<label for="kartu_tempat_lahir"  class="col-sm-4 col-lg-2 control-label">Tempat Lahir</label>
+														<div class="col-sm-7">
+															<input id="kartu_tempat_lahir" class="form-control input-sm" type="text" placeholder="Tempat Lahir" name="kartu_tempat_lahir"  value="">
+														</div>
 													</div>
-												</div>
-											</form>
-                     </div>
+													<div class="form-group">
+														<label for="kartu_tanggal_lahir"  class="col-sm-4 col-lg-2 control-label">Tanggal Lahir</label>
+														<div class="col-sm-7">
+															<div class="input-group input-group-sm date">
+																<div class="input-group-addon">
+																	<i class="fa fa-calendar"></i>
+																</div>
+																<input class="form-control input-sm pull-right" id="tgl_1" name="kartu_tanggal_lahir" placeholder="Tgl. Lahir" type="text" value="">
+															</div>
+														</div>
+													</div>
+													<div class="form-group">
+														<label for="kartu_alamat"  class="col-sm-4 col-lg-2 control-label">Alamat</label>
+														<div class="col-sm-7">
+															<input  id="kartu_alamat" class="form-control input-sm" type="text" placeholder="Alamat" name="kartu_alamat" value="">
+														</div>
+													</div>
+													<div class="form-group">
+														<label for="no_id_kartu" class="col-sm-4 col-lg-2  control-label">Nomor Kartu Peserta</label>
+														<div class="col-sm-7">
+															<input  id="no_id_kartu" class="form-control input-sm required" type="text" placeholder="Nomor Kartu Peserta" name="no_id_kartu" >
+														</div>
+													</div>
+													<div class="form-group">
+														<label for="jenis_keramaian"  class="col-sm-4 col-lg-2 control-label">Gambar Kartu Peserta</label>
+														<div class="col-sm-7">
+															<div class="input-group input-group-sm ">
+																<input type="text" class="form-control" id="file_path">
+																<input type="file" class="hidden" id="file" name="satuan">
+																<span class="input-group-btn">
+																	<button type="button" class="btn btn-info btn-flat"  id="file_browser"><i class="fa fa-search"></i> Browse</button>
+																</span>
+															</div>
+															<p class="help-block text-red">Kosongkan jika tidak ingin mengunggah gambar.</p>
+														</div>
+													</div>
+													<div class="box-footer">
+														<div class="col-xs-12">
+															<button type="reset" class="btn btn-social btn-flat btn-danger btn-sm"><i class="fa fa-times"></i> Batal</button>
+															<button type="submit" class="btn btn-social btn-flat btn-info btn-sm pull-right"><i class="fa fa-check"></i> Simpan</button>
+														</div>
+													</div>
+												</form>
+											</div>
+										</div>
 									</div>
 								</div>
 							</div>
-						</div>
 					</div>
 				</div>
 			</div>
 		</div>
 	</section>
 </div>
+<script type="text/javascript">
+$(document).ready(function(){
+	$('#peserta').on('change', function() {
+		var selectedOption = $(this).find('option:selected');
+		$('#kartu_nama').val(selectedOption[0].dataset.nama);
+		$('#kartu_nik').val(selectedOption[0].dataset.nik);
+		$('#kartu_tempat_lahir').val(selectedOption[0].dataset.tempatlahir);
+		$('#tgl_1').val(selectedOption[0].dataset.tanggallahir);
+		$('#kartu_alamat').val("<?= $individu['alamat_wilayah'];?>");
+	});
 
+	$('#nik').on('change', function() {
+		$('#id_kk').val('');
+	});
+
+});
+</script>


### PR DESCRIPTION
Saat ini ketika menambah peserta baru bantuan keluarga, nama pada Kartu Peserta bersifat statis dan otomatis mengambil nama kepala keluarga, jika akan mengganti nama, nik, tempat/tgl lahir, alamat harus diinput secara manual.

Dengan update ini Nama Peserta di Kartu Peserta Bantuan dapat dipilih secara Dinamis pada menu select yg berisi data semua anggota keluarga dan tidak perlu mengisi manual lagi jika akan mengganti.

Nama yang akan ditampilkan di statistik akan sesuai dengan dengan opsi yg dipilih berdasarkan PR #3149 Opsi tampilkan Nama Peserta (bukan nama Kepala Keluarga) di daftar penerima bantuan.

SEBELUMNYA
![pilih_nama_before](https://user-images.githubusercontent.com/10391199/83881862-78e78700-a76b-11ea-9bbb-0483cd6f2146.PNG)

SESUDAH
![pilih_nama_after](https://user-images.githubusercontent.com/10391199/83881870-7d13a480-a76b-11ea-92fc-f5c09814153f.PNG)

#3027


