### PR TITLE
tambah file .htaccess dalam folder desa/upload

### DIFF
--- a/desa-contoh/upload/.htaccess
+++ b/desa-contoh/upload/.htaccess
@@ -1,0 +1,4 @@
+<FilesMatch "\.(php|php\.|txt)$">
+Order Allow,Deny
+Deny from all
+</FilesMatch>

--- a/donjo-app/models/Database_model.php
+++ b/donjo-app/models/Database_model.php
@@ -115,6 +115,7 @@ class Database_model extends CI_Model {
 			$this->_migrasi_db_cri();
 		}
 		$this->folder_desa_model->amankan_folder_desa();
+		$this->folder_desa_model->tambah_file();
 		$this->surat_master_model->impor_surat_desa();
 		$this->db->where('id', 13)->update('setting_aplikasi', array('value' => TRUE));
 		/*

--- a/donjo-app/models/Folder_desa_model.php
+++ b/donjo-app/models/Folder_desa_model.php
@@ -56,5 +56,15 @@
 		}
 	}
 
+	public function tambah_file($cek = 'desa/upload/*', $cari = '.htaccess', $contoh = 'desa-contoh/upload/.htaccess')
+	{
+		foreach(glob($cek, GLOB_ONLYDIR) as $folder)
+		{
+			$file = "$folder/$cari";
 
+			if(!file_exists($file)) copy($contoh, $file);
+
+			$this->tambah_file("$folder/*");
+		}
+	}
 }

--- a/donjo-app/models/Folder_desa_model.php
+++ b/donjo-app/models/Folder_desa_model.php
@@ -56,15 +56,17 @@
 		}
 	}
 
-	public function tambah_file($cek = 'desa/upload/*', $cari = '.htaccess', $contoh = 'desa-contoh/upload/.htaccess')
+	public function tambah_file($cek = 'desa/upload', $cari = '.htaccess', $contoh = 'desa-contoh/upload/.htaccess')
 	{
-		foreach(glob($cek, GLOB_ONLYDIR) as $folder)
+		if(!file_exists("$cek/$cari")) copy($contoh, "$cek/$cari");
+
+		foreach(glob("$cek/*", GLOB_ONLYDIR) as $folder)
 		{
 			$file = "$folder/$cari";
 
 			if(!file_exists($file)) copy($contoh, $file);
 
-			$this->tambah_file("$folder/*");
+			$this->tambah_file("$folder");
 		}
 	}
 }


### PR DESCRIPTION
Solusi untuk perbaikan terkait issue #3223

Disini sy hanya menambahkan 1 file contoh .htaccess pd folder desa-contoh/upload/artikel. Ketika file .htaccess yg sy ambil sbg contoh masih perlu tambahan configurasi(blum final), maka hanya perlu mengedit 1 file sja. Dan jika sudah final .htaccess bisa mengubah `$cek = 'desa/upload` menjadi `$cek = 'desa-contoh/upload` dan lakukan migrasi agar semua file tercopy ke semua desa-contoh.

```public function tambah_file($cek = 'desa-contoh/upload', $cari = '.htaccess', $contoh = 'desa-contoh/upload/.htaccess')```

Bisa jg digunakan untuk menamahkan file index.php atau file lainnya, tinggal ganti sj nilai variabelnya.