### PR TITLE
Perbaharui Mapbox API dari Classic ke GL

### DIFF
--- a/assets/js/leaflet-mapbox-gl.js
+++ b/assets/js/leaflet-mapbox-gl.js
@@ -1,0 +1,275 @@
+(function (root, factory) {
+    if (typeof define === 'function' && define.amd) {
+        // AMD
+        define(['leaflet', 'mapbox-gl'], factory);
+    } else if (typeof exports === 'object') {
+        // Node, CommonJS-like
+        module.exports = factory(require('leaflet'), require('mapbox-gl'));
+    } else {
+        // Browser globals (root is window)
+        root.returnExports = factory(window.L, window.mapboxgl);
+    }
+}(this, function (L, mapboxgl) {
+    L.MapboxGL = L.Layer.extend({
+            options: {
+            updateInterval: 32,
+            // How much to extend the overlay view (relative to map size)
+            // e.g. 0.1 would be 10% of map view in each direction
+            padding: 0.1,
+            // whether or not to register the mouse and keyboard
+            // events on the mapbox overlay
+            interactive: false
+        },
+
+        initialize: function (options) {
+            L.setOptions(this, options);
+
+            if (options.accessToken) {
+                mapboxgl.accessToken = options.accessToken;
+            }
+
+            // setup throttling the update event when panning
+            this._throttledUpdate = L.Util.throttle(this._update, this.options.updateInterval, this);
+        },
+
+        onAdd: function (map) {
+            if (!this._container) {
+                this._initContainer();
+            }
+
+            map.getPanes().tilePane.appendChild(this._container);
+
+            this._initGL();
+
+            this._offset = this._map.containerPointToLayerPoint([0, 0]);
+
+            // work around https://github.com/mapbox/mapbox-gl-leaflet/issues/47
+            if (map.options.zoomAnimation) {
+                L.DomEvent.on(map._proxy, L.DomUtil.TRANSITION_END, this._transitionEnd, this);
+            }
+        },
+
+        onRemove: function (map) {
+            if (this._map._proxy && this._map.options.zoomAnimation) {
+                L.DomEvent.off(this._map._proxy, L.DomUtil.TRANSITION_END, this._transitionEnd, this);
+            }
+
+            map.getPanes().tilePane.removeChild(this._container);
+            this._glMap.remove();
+            this._glMap = null;
+        },
+
+        getEvents: function () {
+            return {
+                move: this._throttledUpdate, // sensibly throttle updating while panning
+                zoomanim: this._animateZoom, // applys the zoom animation to the <canvas>
+                zoom: this._pinchZoom, // animate every zoom event for smoother pinch-zooming
+                zoomstart: this._zoomStart, // flag starting a zoom to disable panning
+                zoomend: this._zoomEnd,
+                resize: this._resize
+            };
+        },
+
+        getMapboxMap: function () {
+            return this._glMap;
+        },
+
+        getCanvas: function () {
+            return this._glMap.getCanvas();
+        },
+
+        getSize: function () {
+            return this._map.getSize().multiplyBy(1 + this.options.padding * 2);
+        },
+
+        getBounds: function () {
+            var halfSize = this.getSize().multiplyBy(0.5);
+            var center = this._map.latLngToContainerPoint(this._map.getCenter());
+            return L.latLngBounds(
+                this._map.containerPointToLatLng(center.subtract(halfSize)),
+                this._map.containerPointToLatLng(center.add(halfSize))
+            );
+        },
+
+        getContainer: function () {
+            return this._container;
+        },
+
+        _initContainer: function () {
+            var container = this._container = L.DomUtil.create('div', 'leaflet-gl-layer');
+
+            var size = this.getSize();
+            var offset = this._map.getSize().multiplyBy(this.options.padding);
+            container.style.width  = size.x + 'px';
+            container.style.height = size.y + 'px';
+
+            var topLeft = this._map.containerPointToLayerPoint([0, 0]).subtract(offset);
+
+            L.DomUtil.setPosition(container, topLeft);
+        },
+
+        _initGL: function () {
+            var center = this._map.getCenter();
+
+            var options = L.extend({}, this.options, {
+                container: this._container,
+                center: [center.lng, center.lat],
+                zoom: this._map.getZoom() - 1,
+                attributionControl: false
+            });
+
+            this._glMap = new mapboxgl.Map(options);
+
+            // allow GL base map to pan beyond min/max latitudes
+            this._glMap.transform.latRange = null;
+
+            if (this._glMap._canvas.canvas) {
+                // older versions of mapbox-gl surfaced the canvas differently
+                this._glMap._actualCanvas = this._glMap._canvas.canvas;
+            } else {
+                this._glMap._actualCanvas = this._glMap._canvas;
+            }
+
+            // treat child <canvas> element like L.ImageOverlay
+            var canvas = this._glMap._actualCanvas;
+            L.DomUtil.addClass(canvas, 'leaflet-image-layer');
+            L.DomUtil.addClass(canvas, 'leaflet-zoom-animated');
+            if (this.options.interactive) {
+                L.DomUtil.addClass(canvas, 'leaflet-interactive');
+            }
+            if (this.options.className) {
+                L.DomUtil.addClass(canvas, this.options.className);
+            }
+        },
+
+        _update: function (e) {
+            // update the offset so we can correct for it later when we zoom
+            this._offset = this._map.containerPointToLayerPoint([0, 0]);
+
+            if (this._zooming) {
+                return;
+            }
+
+            var size = this.getSize(),
+                container = this._container,
+                gl = this._glMap,
+                offset = this._map.getSize().multiplyBy(this.options.padding),
+                topLeft = this._map.containerPointToLayerPoint([0, 0]).subtract(offset);
+
+            L.DomUtil.setPosition(container, topLeft);
+
+            var center = this._map.getCenter();
+
+            // gl.setView([center.lat, center.lng], this._map.getZoom() - 1, 0);
+            // calling setView directly causes sync issues because it uses requestAnimFrame
+
+            var tr = gl.transform;
+            tr.center = mapboxgl.LngLat.convert([center.lng, center.lat]);
+            tr.zoom = this._map.getZoom() - 1;
+
+            if (gl.transform.width !== size.x || gl.transform.height !== size.y) {
+                container.style.width  = size.x + 'px';
+                container.style.height = size.y + 'px';
+                if (gl._resize !== null && gl._resize !== undefined){
+                    gl._resize();
+                } else {
+                    gl.resize();
+                }
+            } else {
+                // older versions of mapbox-gl surfaced update publicly
+                if (gl._update !== null && gl._update !== undefined){
+                    gl._update();
+                } else {
+                    gl.update();
+                }
+            }
+        },
+
+        // update the map constantly during a pinch zoom
+        _pinchZoom: function (e) {
+            this._glMap.jumpTo({
+                zoom: this._map.getZoom() - 1,
+                center: this._map.getCenter()
+            });
+        },
+
+        // borrowed from L.ImageOverlay
+        // https://github.com/Leaflet/Leaflet/blob/master/src/layer/ImageOverlay.js#L139-L144
+        _animateZoom: function (e) {
+            var scale = this._map.getZoomScale(e.zoom);
+            var padding = this._map.getSize().multiplyBy(this.options.padding * scale);
+            var viewHalf = this.getSize()._divideBy(2);
+            // corrections for padding (scaled), adapted from
+            // https://github.com/Leaflet/Leaflet/blob/master/src/map/Map.js#L1490-L1508
+            var topLeft = this._map.project(e.center, e.zoom)
+                ._subtract(viewHalf)
+                ._add(this._map._getMapPanePos()
+                .add(padding))._round();
+            var offset = this._map.project(this._map.getBounds().getNorthWest(), e.zoom)
+                ._subtract(topLeft);
+
+            L.DomUtil.setTransform(
+                this._glMap._actualCanvas,
+                offset.subtract(this._offset),
+                scale
+            );
+        },
+
+        _zoomStart: function (e) {
+            this._zooming = true;
+        },
+
+        _zoomEnd: function () {
+            var scale = this._map.getZoomScale(this._map.getZoom()),
+                offset = this._map._latLngToNewLayerPoint(
+                    this._map.getBounds().getNorthWest(),
+                    this._map.getZoom(),
+                    this._map.getCenter()
+                );
+
+            L.DomUtil.setTransform(
+                this._glMap._actualCanvas,
+                offset.subtract(this._offset),
+                scale
+            );
+
+            this._zooming = false;
+
+            this._update();
+        },
+
+        _transitionEnd: function (e) {
+            L.Util.requestAnimFrame(function () {
+                var zoom = this._map.getZoom();
+                var center = this._map.getCenter();
+                var offset = this._map.latLngToContainerPoint(
+                    this._map.getBounds().getNorthWest()
+                );
+
+                // reset the scale and offset
+                L.DomUtil.setTransform(this._glMap._actualCanvas, offset, 1);
+
+                // enable panning once the gl map is ready again
+                this._glMap.once('moveend', L.Util.bind(function () {
+                    this._zoomEnd();
+                }, this));
+
+                // update the map position
+                this._glMap.jumpTo({
+                    center: center,
+                    zoom: zoom - 1
+                });
+            }, this);
+        },
+
+        _resize: function (e) {
+            this._transitionEnd(e);
+        }
+    });
+
+    L.mapboxGL = function (options) {
+        return new L.MapboxGL(options);
+    };
+
+}));
+

--- a/assets/js/peta.js
+++ b/assets/js/peta.js
@@ -102,14 +102,25 @@ function set_marker_content(marker, daftar_path, warna, judul, nama_wil, content
 function getBaseLayers(peta, access_token)
 {
 	//Menampilkan BaseLayers Peta
-	var defaultLayer = L.tileLayer.provider('OpenStreetMap.Mapnik').addTo(peta);
+	var defaultLayer = L.tileLayer.provider('OpenStreetMap.Mapnik', {attribution: '<a href="https://openstreetmap.org/copyright">© OpenStreetMap</a> | <a href="https://github.com/OpenSID/OpenSID">OpenSID</a>'}).addTo(peta);
+
+	var mbGLsat = L.mapboxGL({
+		accessToken: access_token,
+		style: 'mapbox://styles/mapbox/satellite-v9',
+		attribution: '<a href="https://www.mapbox.com/about/maps">© Mapbox</a> | <a href="https://github.com/OpenSID/OpenSID">OpenSID</a>',
+	});
+
+	var mbGLstrsat = L.mapboxGL({
+		accessToken: access_token,
+		style: 'mapbox://styles/mapbox/satellite-streets-v11',
+		attribution: '<a href="https://www.mapbox.com/about/maps">© Mapbox</a> | <a href="https://github.com/OpenSID/OpenSID">OpenSID</a>',
+	});
 
 	var baseLayers = {
 		'OpenStreetMap': defaultLayer,
-		'OpenStreetMap H.O.T.': L.tileLayer.provider('OpenStreetMap.HOT'),
-		'Mapbox Streets' : L.tileLayer('https://api.mapbox.com/v4/mapbox.streets/{z}/{x}/{y}@2x.png?access_token='+access_token, {attribution: '<a href="https://www.mapbox.com/about/maps">© Mapbox</a> <a href="https://openstreetmap.org/copyright">© OpenStreetMap</a> | <a href="https://mapbox.com/map-feedback/">Improve this map</a>'}),
-		'Mapbox Outdoors' : L.tileLayer('https://api.mapbox.com/v4/mapbox.outdoors/{z}/{x}/{y}@2x.png?access_token='+access_token, {attribution: '<a href="https://www.mapbox.com/about/maps">© Mapbox</a> <a href="https://openstreetmap.org/copyright">© OpenStreetMap</a> | <a href="https://mapbox.com/map-feedback/">Improve this map</a>'}),
-		'Mapbox Streets Satellite' : L.tileLayer('https://api.mapbox.com/v4/mapbox.streets-satellite/{z}/{x}/{y}@2x.png?access_token='+access_token, {attribution: '<a href="https://www.mapbox.com/about/maps">© Mapbox</a> <a href="https://openstreetmap.org/copyright">© OpenStreetMap</a> | <a href="https://mapbox.com/map-feedback/">Improve this map</a>'}),
+		'OpenStreetMap H.O.T.': L.tileLayer.provider('OpenStreetMap.HOT', {attribution: '<a href="https://openstreetmap.org/copyright">© OpenStreetMap</a> | <a href="https://github.com/OpenSID/OpenSID">OpenSID</a>'}),
+		'Mapbox Citra Satelit' : mbGLsat,
+		'Mapbox Citra Satelit + Jalan' : mbGLstrsat,
 	};
 	return baseLayers;
 }

--- a/donjo-app/views/header.php
+++ b/donjo-app/views/header.php
@@ -51,6 +51,7 @@
 		<link rel="stylesheet" href="<?= base_url()?>assets/css/MarkerCluster.css" />
 		<link rel="stylesheet" href="<?= base_url()?>assets/css/MarkerCluster.Default.css" />
 		<link rel="stylesheet" href="<?= base_url()?>assets/css/leaflet-measure-path.css" />
+		<link href="https://api.mapbox.com/mapbox-gl-js/v1.11.0/mapbox-gl.css" rel="stylesheet" />
 
 		<!-- Untuk ubahan style desa -->
 		<?php if (is_file("desa/css/siteman.css")): ?>
@@ -71,6 +72,8 @@
 		<script src="<?= base_url()?>assets/js/peta.js"></script>
 		<script src="<?= base_url()?>assets/js/leaflet-measure-path.js"></script>
 		<script src="<?= base_url()?>assets/js/apbdes_manual.js"></script>
+		<script src="https://api.mapbox.com/mapbox-gl-js/v1.11.0/mapbox-gl.js"></script>
+		<script src="<?= base_url()?>assets/js/leaflet-mapbox-gl.js"></script>
 
 		<!-- Diperlukan untuk global automatic base_url oleh external js file -->
 		<script type="text/javascript">

--- a/donjo-app/views/widgets/peta_lokasi_kantor.php
+++ b/donjo-app/views/widgets/peta_lokasi_kantor.php
@@ -108,12 +108,17 @@
 	var lokasi_kantor = L.map('map_canvas').setView(posisi, zoom);
 
 	//Menampilkan BaseLayers Peta
-	var defaultLayer = L.tileLayer.provider('OpenStreetMap.Mapnik').addTo(lokasi_kantor);
+	var defaultLayer = L.tileLayer.provider('OpenStreetMap.Mapnik', {attribution: '<a href="https://openstreetmap.org/copyright">© OpenStreetMap</a> | <a href="https://github.com/OpenSID/OpenSID">OpenSID</a>'}).addTo(lokasi_kantor);
 
-	var baseLayers =
-	{
+	var mbGLstrsat = L.mapboxGL({
+		accessToken: '<?=$this->setting->google_key?>',
+		style: 'mapbox://styles/mapbox/satellite-streets-v11',
+		attribution: '<a href="https://www.mapbox.com/about/maps">© Mapbox</a> | <a href="https://github.com/OpenSID/OpenSID">OpenSID</a>',
+	});
+
+	var baseLayers = {
 		'OpenStreetMap': defaultLayer,
-		'Mapbox Streets Satellite' : L.tileLayer('https://api.mapbox.com/v4/mapbox.streets-satellite/{z}/{x}/{y}@2x.png?access_token=<?=$this->setting->google_key?>', {attribution: '<a href="https://www.mapbox.com/about/maps">© Mapbox</a> <a href="https://openstreetmap.org/copyright">© OpenStreetMap</a>'}),
+		'Mapbox Satelit' : mbGLstrsat,
 	};
 
 	L.control.layers(baseLayers, null, {position: 'topright', collapsed: true}).addTo(lokasi_kantor);

--- a/donjo-app/views/widgets/peta_wilayah_desa.php
+++ b/donjo-app/views/widgets/peta_wilayah_desa.php
@@ -32,12 +32,18 @@
   var wilayah_desa = L.map('map_wilayah').setView(posisi, zoom);
 
   //Menampilkan BaseLayers Peta
-  var defaultLayer = L.tileLayer.provider('OpenStreetMap.Mapnik').addTo(wilayah_desa);
+	var defaultLayer = L.tileLayer.provider('OpenStreetMap.Mapnik', {attribution: '<a href="https://openstreetmap.org/copyright">© OpenStreetMap</a> | <a href="https://github.com/OpenSID/OpenSID">OpenSID</a>'}).addTo(wilayah_desa);
 
-  var baseLayers = {
-    'OpenStreetMap': defaultLayer,
-    'Mapbox Streets Satellite' : L.tileLayer('https://api.mapbox.com/v4/mapbox.streets-satellite/{z}/{x}/{y}@2x.png?access_token=<?=$this->setting->google_key?>', {attribution: '<a href="https://www.mapbox.com/about/maps">© Mapbox</a> <a href="https://openstreetmap.org/copyright">© OpenStreetMap</a>'}),
-  };
+	var mbGLstrsat = L.mapboxGL({
+		accessToken: '<?=$this->setting->google_key?>',
+		style: 'mapbox://styles/mapbox/satellite-streets-v11',
+		attribution: '<a href="https://www.mapbox.com/about/maps">© Mapbox</a> | <a href="https://github.com/OpenSID/OpenSID">OpenSID</a>',
+	});
+
+	var baseLayers = {
+		'OpenStreetMap': defaultLayer,
+		'Mapbox Satelit' : mbGLstrsat,
+	};
 
   L.control.layers(baseLayers, null, {position: 'topright', collapsed: true}).addTo(wilayah_desa);
 

--- a/themes/hadakewa/layouts/header.php
+++ b/themes/hadakewa/layouts/header.php
@@ -36,6 +36,7 @@
 
 		<link type='text/css' href="<?= base_url()?>assets/front/css/first.css" rel='Stylesheet' />
 		<link rel="stylesheet" href="<?= base_url()?>assets/css/leaflet.css" />
+		<link href="https://api.mapbox.com/mapbox-gl-js/v1.11.0/mapbox-gl.css" rel="stylesheet" />
 
 		<!-- Styles untuk tema dan penyesuaiannya di folder desa -->
 		<link type='text/css' href="<?= base_url().$this->theme_folder.'/'.$this->theme.'/css/first.css'?>" rel='Stylesheet' />
@@ -55,6 +56,8 @@
 		<script src="<?= base_url()?>assets/front/js/layout.js"></script>
 		<script src="<?= base_url()?>assets/front/js/bootstrap.min.js"></script>
 		<script src="<?= base_url()?>assets/js/leaflet-providers.js"></script>
+		<script src="https://api.mapbox.com/mapbox-gl-js/v1.11.0/mapbox-gl.js"></script>
+		<script src="<?= base_url()?>assets/js/leaflet-mapbox-gl.js"></script>
 
 		<!-- Datatables -->
 		<link rel="stylesheet" type="text/css" href="<?= base_url() ?>assets/bootstrap/css/dataTables.bootstrap.min.css">

--- a/themes/klasik/layouts/header.php
+++ b/themes/klasik/layouts/header.php
@@ -46,12 +46,15 @@
 			<link type='text/css' href="<?= base_url()?>assets/front/css/colorbox.css" rel='Stylesheet' />
 		<?php endif ?>
 		<link rel="stylesheet" href="<?= base_url()?>assets/css/leaflet.css" />
+		<link href="https://api.mapbox.com/mapbox-gl-js/v1.11.0/mapbox-gl.css" rel="stylesheet" />
 
 		<script src="<?= base_url()?>assets/front/js/jquery.js"></script>
 		<script src="<?= base_url()?>assets/js/leaflet.js"></script>
 		<script src="<?= base_url()?>assets/front/js/layout.js"></script>
 		<script src="<?= base_url()?>assets/front/js/bootstrap.min.js"></script>
 		<script src="<?= base_url()?>assets/js/leaflet-providers.js"></script>
+		<script src="https://api.mapbox.com/mapbox-gl-js/v1.11.0/mapbox-gl.js"></script>
+		<script src="<?= base_url()?>assets/js/leaflet-mapbox-gl.js"></script>
 
 		<!-- Datatables -->
 		<link rel="stylesheet" type="text/css" href="<?= base_url() ?>assets/bootstrap/css/dataTables.bootstrap.min.css">


### PR DESCRIPTION
Sejak 1 Juni 2020 Mapbox API Classic sudah tidak disupport dan data petanya sudah tidak diupdate lagi.
Untuk support berkesinambungan dari mapbox dan mendapatkan data peta terbaru maka Mapbox API perlu diperbaharui ke Mapbox GL