### PR TITLE
Fitur notifikasi update #3202 #3204

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,4 +43,11 @@ info.php
 **/.DS_Store
 mitra
 
+# Abaikan file milik library Release dan Curly
+*.pem
+version.json
+
+# Abaikan file cache milik phpintel (plugin sublime text) - nitip pak
+.phpintel/*
+
 

--- a/donjo-app/controllers/Hom_sid.php
+++ b/donjo-app/controllers/Hom_sid.php
@@ -7,6 +7,10 @@ class Hom_sid extends Admin_Controller {
 	{
 		parent::__construct();
 		session_start();
+
+		// Implementasi notifikasi update (github issue id: #3202 #3204)
+		$this->load->library('release');
+
 		$this->load->model('header_model');
 		$this->load->model('program_bantuan_model');
 		$this->load->model('surat_model');
@@ -15,6 +19,11 @@ class Hom_sid extends Admin_Controller {
 
 	public function index()
 	{
+		// Implementasi notifikasi update (github issue id: #3202 #3204)
+		$data['update_available'] = $this->release->isAvailable();
+		$data['current_version'] = $this->release->getCurrentVersion();
+		$data['latest_version'] = $this->release->getLatestVersion();
+
 		// Pengambilan data penduduk untuk ditampilkan widget Halaman Dashboard (modul Home SID)
 		$data['penduduk'] = $this->header_model->penduduk_total();
 		$data['keluarga'] = $this->header_model->keluarga_total();

--- a/donjo-app/helpers/opensid_helper.php
+++ b/donjo-app/helpers/opensid_helper.php
@@ -865,7 +865,8 @@ function convertToBytes(string $from)
       return preg_replace('/[^\d]/', '', $from);
   }
 
-  $exponent = array_flip($units)[$suffix] ?? null;
+  $exponent = array_flip($units);
+  $exponent = isset($exponent[$suffix]) ? $exponent[$suffix] : null;
   if($exponent === null) {
       return null;
   }

--- a/donjo-app/libraries/Curly.php
+++ b/donjo-app/libraries/Curly.php
@@ -1,0 +1,375 @@
+<?php
+/**
+ * Curly - Simple cURL Library for PHP 5.4+
+ * Ported to PHP 5.3+ by @esyede
+ *
+ *  @author  Suyadi <suyadi.1992@gmail.com>
+ * @license  MIT
+ * @see      https://github.com/esyede/curly
+ */
+
+namespace Esyede;
+
+class Curly
+{
+    /**
+     * Activate secure connection?
+     *
+     * @var bool
+     */
+    public static $secure = true;
+
+    /**
+     * Path to CA bundle file (absolute).
+     *
+     * @var string
+     */
+    public static $certificate;
+
+    /**
+     * Link for downloading CA bundle.
+     *
+     * @var string
+     */
+    public static $obtain = 'https://curl.haxx.se/ca/cacert.pem';
+
+    /**
+     * Send a GET request.
+     *
+     * @param string $url
+     * @param array  $params
+     * @param array  $options
+     *
+     * @return \stdClass
+     */
+    public static function get($url, array $params = array(), array $options = array())
+    {
+        return static::request('get', $url, $params, $options);
+    }
+
+    /**
+     * Send a POST request.
+     *
+     * @param string $url
+     * @param array  $params
+     * @param array  $options
+     *
+     * @return \stdClass
+     */
+    public static function post($url, array $params = array(), array $options = array())
+    {
+        return static::request('post', $url, $params, $options);
+    }
+
+    /**
+     * Send a PUT request.
+     *
+     * @param string $url
+     * @param array  $params
+     * @param array  $options
+     *
+     * @return \stdClass
+     */
+    public static function put($url, array $params = array(), array $options = array())
+    {
+        return static::request('put', $url, $params, $options);
+    }
+
+    /**
+     * Send a DELETE request.
+     *
+     * @param string $url
+     * @param array  $params
+     * @param array  $options
+     *
+     * @return \stdClass
+     */
+    public static function delete($url, array $params = array(), array $options = array())
+    {
+        return static::request('delete', $url, $params, $options);
+    }
+
+    /**
+     * Send a request.
+     *
+     * @param string $method
+     * @param string $url
+     * @param array  $params
+     * @param array  $options
+     *
+     * @return \stdClass
+     */
+    public static function request($method = 'get', $url, array $params = array(), array $options = array())
+    {
+        if (! static::available()) {
+            throw new \RuntimeException('cURL extension is not available.');
+        }
+
+        if (! in_array($method, array('get', 'post', 'put', 'delete'))) {
+            throw new \Exception('Request method is not supported: '.$method);
+        }
+
+        // Set lokasi default penyimpanan sertifikat ssl.
+        if (is_null(static::$certificate)) {
+            static::$certificate = dirname(__FILE__).DIRECTORY_SEPARATOR.'cacert.pem';
+        }
+
+        // Obtain the CA bundle if we do not habe yet.
+        // It is important for us to be able to use TLS later on.
+        if (! is_file(static::$certificate)) {
+            try {
+                // Deactivate secure connection because we don't have the CA bundle yet.
+                // We will re-activate it later on.
+                static::$secure = false;
+
+                // Let's download the CA bundlen.
+                static::download(static::$obtain, static::$certificate);
+
+                // Then give it a read permission.
+                chmod(static::$certificate, 0644);
+
+                // Re-activate secure connection.
+                static::$secure = true;
+            } catch (\Throwable $e) {
+                // Error on PHP 7+
+                throw new \Exception('Unable to obtain CA bundle: '.$e->getMessage());
+            } catch (\Exception $e) {
+                // Error on PHP 5
+                throw new \Exception('Unable to obtain CA bundle: '.$e->getMessage());
+            }
+        }
+
+        $curl = curl_init();
+
+        curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, static::$secure ? 1 : 0);
+        curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, static::$secure ? 2 : 0);
+        curl_setopt($curl, CURLOPT_CAINFO, static::$secure ? static::$certificate : null);
+        curl_setopt($curl, CURLOPT_CAPATH, static::$secure ? static::$certificate : null);
+
+        curl_setopt($curl, CURLOPT_AUTOREFERER, 1);
+        curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
+        curl_setopt($curl, CURLOPT_USERAGENT, static::agent());
+
+        $query = empty($params) ? null : http_build_query($params, '', '&', PHP_QUERY_RFC1738);
+
+        switch (strtolower($method)) {
+            case 'get':
+                $url .= $query ? '?'.$query : '';
+                curl_setopt($curl, CURLOPT_HTTPGET, 1);
+                break;
+
+            case 'post':
+                if ($query) {
+                    curl_setopt($curl, CURLOPT_POSTFIELDS, $query);
+                }
+
+                // Check if user passes custom options to the $options parameter.
+                // Then add a proper Content-Type header to our query string.
+                if (isset($options[CURLOPT_HTTPHEADER]) && is_array($options[CURLOPT_HTTPHEADER])) {
+                    $options[CURLOPT_HTTPHEADER] = array_merge(
+                        $options[CURLOPT_HTTPHEADER],
+                        array('Content-Type: application/x-www-form-urlencoded')
+                    );
+                } else {
+                    $options[CURLOPT_HTTPHEADER] = array('Content-Type: application/x-www-form-urlencoded');
+                }
+
+                curl_setopt($curl, CURLOPT_POST, 1);
+                break;
+
+            case 'put':
+                if ($query) {
+                    curl_setopt($curl, CURLOPT_POSTFIELDS, $query);
+                }
+
+                // Check if user passes custom options to the $options parameter.
+                // Then add a proper Content-Type header to our query string.
+                if (isset($options[CURLOPT_HTTPHEADER]) && is_array($options[CURLOPT_HTTPHEADER])) {
+                    $options[CURLOPT_HTTPHEADER] = array_merge(
+                        $options[CURLOPT_HTTPHEADER],
+                        array('Content-Type: application/x-www-form-urlencoded')
+                    );
+                } else {
+                    $options[CURLOPT_HTTPHEADER] = array('Content-Type: application/x-www-form-urlencoded');
+                }
+
+                curl_setopt($curl, CURLOPT_CUSTOMREQUEST, 'PUT');
+                break;
+
+            case 'delete':
+                if ($query) {
+                    curl_setopt($curl, CURLOPT_POSTFIELDS, $query);
+                }
+
+                // Check if the programmer passes custom options to the $options parameter.
+                // Then add a proper Content-Type header to our query string.
+                if (isset($options[CURLOPT_HTTPHEADER]) && is_array($options[CURLOPT_HTTPHEADER])) {
+                    $options[CURLOPT_HTTPHEADER] = array_merge(
+                        $options[CURLOPT_HTTPHEADER],
+                        array('Content-Type: application/x-www-form-urlencoded')
+                    );
+                } else {
+                    $options[CURLOPT_HTTPHEADER] = array('Content-Type: application/x-www-form-urlencoded');
+                }
+
+                curl_setopt($curl, CURLOPT_CUSTOMREQUEST, 'DELETE');
+                break;
+
+            default:
+                throw new \Exception('Usupported request method: '.strtoupper($method));
+                break;
+        }
+
+        if (! empty($options)) {
+            curl_setopt_array($curl, $options);
+        }
+
+        curl_setopt($curl, CURLOPT_URL, $url);
+
+        $body = curl_exec($curl);
+
+        if (false === $body) {
+            $code = curl_errno($curl);
+            $message = curl_error($curl);
+
+            curl_close($curl);
+
+            throw new \Exception($message, $code);
+        }
+
+        $header = (object) curl_getinfo($curl);
+
+        curl_close($curl);
+
+        // Encode response-body into json if the programmer want to.
+        if (false !== strpos($header->content_type, '/json')) {
+            $body = json_decode($body);
+        }
+
+        return (object) compact('header', 'body');
+    }
+
+    /**
+     * Download file from given URL.
+     *
+     * @param string $url
+     * @param string $destination
+     * @param array  $options
+     *
+     * @return void
+     */
+    public static function download($url, $destination, array $options = array())
+    {
+        if (! static::available()) {
+            throw new \Exception('cURL extension is not available.');
+        }
+
+        if (is_file($destination)) {
+            throw new \Exception('Destination path already exists: '.$destination);
+        }
+
+        $fopen = false;
+
+        if (false === ($fopen = fopen($destination, 'w+'))) {
+            throw new \Exception('Unable to open destination file: '.$destination);
+        }
+
+        $curl = curl_init();
+
+        curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, static::$secure ? 1 : 0);
+        curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, static::$secure ? 2 : 0);
+        curl_setopt($curl, CURLOPT_CAINFO, static::$secure ? static::$certificate : null);
+        curl_setopt($curl, CURLOPT_CAPATH, static::$secure ? static::$certificate : null);
+
+        curl_setopt($curl, CURLOPT_FOLLOWLOCATION, 1);
+        curl_setopt($curl, CURLOPT_AUTOREFERER, 1);
+        curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
+        curl_setopt($curl, CURLOPT_USERAGENT, static::agent());
+        curl_setopt($curl, CURLOPT_URL, $url);
+        curl_setopt($curl, CURLOPT_FILE, $fopen);
+
+        if (! empty($options)) {
+            curl_setopt_array($curl, $options);
+        }
+
+        $body = curl_exec($curl);
+
+        if (false === $body) {
+            $code = curl_errno($curl);
+            $message = curl_error($curl);
+
+            curl_close($curl);
+            fclose($fopen);
+
+            throw new \Exception($message, $code);
+        }
+
+        curl_close($curl);
+        fclose($fopen);
+
+        return true;
+    }
+
+    /**
+     * Check if cURL extension is enabled.
+     *
+     * @return bool
+     */
+    public static function available()
+    {
+        return extension_loaded('curl') && is_callable('curl_init');
+    }
+
+    /**
+     * Create a fake user-agent for our request.
+     * Some site such as github refuses the connection
+     * if it doesn't contains User-Agent header.
+     *
+     * @return string
+     */
+    public static function agent()
+    {
+        $year = (int) gmdate('Y');
+        $year = ($year < 2020) ? 2020 : $year;
+
+        // Increase version number based on year.
+        $version = 77 + ($year - 2020) + 2;
+
+        $agents = [
+            'Windows' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:[v].0) Gecko/20100101 Firefox/[v].0',
+            'Linux' => 'Mozilla/5.0 (Linux x86_64; rv:[v].0) Gecko/20100101 Firefox/[v].0',
+            'Darwin' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:[v].0) Gecko/20100101 Firefox/[v].0',
+            'BSD' => 'Mozilla/5.0 (X11; FreeBSD amd64; rv:[v].0) Gecko/20100101 Firefox/[v].0',
+            'Solaris' => 'Mozilla/5.0 (Solaris; Solaris x86_64; rv:[v].0) Gecko/20100101 Firefox/[v].0',
+        ];
+
+        $platform = static::platform();
+        $platform = 'Unknown' === $platform ? 'Linux' : $platform;
+
+        return str_replace('[v]', $version, $agents[$platform]);
+    }
+
+    /**
+     * Get server's platform / operating system.
+     *
+     * @return string
+     */
+    public static function platform()
+    {
+        if ('\\' === DIRECTORY_SEPARATOR) {
+            return 'Windows';
+        }
+
+        $platforms = [
+            'Darwin' => 'Darwin',
+            'DragonFly' => 'BSD',
+            'FreeBSD' => 'BSD',
+            'NetBSD' => 'BSD',
+            'OpenBSD' => 'BSD',
+            'Linux' => 'Linux',
+            'SunOS' => 'Solaris',
+        ];
+
+        return isset($platforms[PHP_OS]) ? $platforms[PHP_OS] : 'Unknown';
+    }
+}

--- a/donjo-app/libraries/Curly.php
+++ b/donjo-app/libraries/Curly.php
@@ -335,13 +335,13 @@ class Curly
         // Increase version number based on year.
         $version = 77 + ($year - 2020) + 2;
 
-        $agents = [
+        $agents = array(
             'Windows' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:[v].0) Gecko/20100101 Firefox/[v].0',
             'Linux' => 'Mozilla/5.0 (Linux x86_64; rv:[v].0) Gecko/20100101 Firefox/[v].0',
             'Darwin' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:[v].0) Gecko/20100101 Firefox/[v].0',
             'BSD' => 'Mozilla/5.0 (X11; FreeBSD amd64; rv:[v].0) Gecko/20100101 Firefox/[v].0',
             'Solaris' => 'Mozilla/5.0 (Solaris; Solaris x86_64; rv:[v].0) Gecko/20100101 Firefox/[v].0',
-        ];
+        );
 
         $platform = static::platform();
         $platform = 'Unknown' === $platform ? 'Linux' : $platform;
@@ -360,7 +360,7 @@ class Curly
             return 'Windows';
         }
 
-        $platforms = [
+        $platforms = array(
             'Darwin' => 'Darwin',
             'DragonFly' => 'BSD',
             'FreeBSD' => 'BSD',
@@ -368,7 +368,7 @@ class Curly
             'OpenBSD' => 'BSD',
             'Linux' => 'Linux',
             'SunOS' => 'Solaris',
-        ];
+        );
 
         return isset($platforms[PHP_OS]) ? $platforms[PHP_OS] : 'Unknown';
     }

--- a/donjo-app/libraries/Release.php
+++ b/donjo-app/libraries/Release.php
@@ -174,7 +174,7 @@ class Release
             }
         }
 
-        return json_decode(file_get_contents($this->cache));
+        return json_decode($this->readCache($this->cache));
     }
 
     /**
@@ -191,7 +191,7 @@ class Release
         $file = $this->cache;
         $interval = $this->interval;
 
-        return ! is_file($file) || (is_file($file) && time() - filemtime($file) < $interval);
+        return ! is_file($file) || (is_file($file) && (time() - filemtime($file)) < $interval);
     }
 
     /**
@@ -229,5 +229,15 @@ class Release
 
             file_put_contents($file, $cache, LOCK_EX);
         }
+    }
+
+    /**
+     * Baca file cache.
+     *
+     * @return string
+     */
+    public function readCache()
+    {
+        return file_get_contents($this->cache);
     }
 }

--- a/donjo-app/libraries/Release.php
+++ b/donjo-app/libraries/Release.php
@@ -155,7 +155,7 @@ class Release
     public function resyncWithOfficialRepository()
     {
         if ($this->cacheIsOutdated()) {
-            \Esyede\Curly::$certificate = FCPATH.'/cacert.pem';
+            \Esyede\Curly::$certificate = FCPATH.DIRECTORY_SEPARATOR.'cacert.pem';
             $response = \Esyede\Curly::get($this->api);
 
             if ($response instanceof \stdClass) {
@@ -181,7 +181,7 @@ class Release
      * Cek apakah data cache sudah kadaluwarsa atau belum.
      * Cache dianggap kadaluwarsa jika:
      *   - File cachenya belum ada di server kita, atau
-     *   - File cache sudah ada tetapi waktu creation-time filenya sudah
+     *   - File cache sudah ada tetapi waktu modified-time filenya sudah
      *     lebih dari interval yang ditentukan.
      *
      * @return bool
@@ -191,7 +191,7 @@ class Release
         $file = $this->cache;
         $interval = $this->interval;
 
-        return ! is_file($file) || (is_file($file) && time() - filectime($file) < $interval);
+        return ! is_file($file) || (is_file($file) && time() - filemtime($file) < $interval);
     }
 
     /**

--- a/donjo-app/libraries/Release.php
+++ b/donjo-app/libraries/Release.php
@@ -156,7 +156,10 @@ class Release
     {
         if ($this->cacheIsOutdated()) {
             \Esyede\Curly::$certificate = FCPATH.DIRECTORY_SEPARATOR.'cacert.pem';
-            $response = \Esyede\Curly::get($this->api);
+
+            $options = array(CURLOPT_HTTPHEADER => array('Accept' => 'application/vnd.github.v3+json'));
+
+            $response = \Esyede\Curly::get($this->api, [], $options);
 
             if ($response instanceof \stdClass) {
                 $response = [

--- a/donjo-app/libraries/Release.php
+++ b/donjo-app/libraries/Release.php
@@ -1,0 +1,233 @@
+<?php
+
+class Release
+{
+    /**
+     * Api endpoint latest release.
+     *
+     * @var string
+     */
+    protected $api = 'https://api.github.com/repos/opensid/opensid/releases/latest';
+
+    /**
+     * Lokasi file cache (absolute)
+     * Default: [FCPATH]/version.json
+     *
+     * @var string
+     */
+    protected $cache;
+
+    /**
+     * Interval waktu untuk sinkronisasi ulang data cache dengan yang ada di github.
+     * Satuan yang digunakan adalah satuan hari.
+     * Default: 7 hari
+     *
+     * @var int
+     */
+    protected $interval;
+
+    /**
+     * Konstruktor
+     */
+    public function __construct()
+    {
+        if (! class_exists('Esyede\Curly')) {
+            require_once dirname(__FILE__).DIRECTORY_SEPARATOR.'Curly.php';
+        }
+
+        if (! $this->cache) {
+            $this->setCacheFolder(FCPATH);
+        }
+
+        if (! $this->interval) {
+            $this->setInterval(7);
+        }
+    }
+
+
+    /**
+     * Set interval waktu sinkronisasi cache dengan repo github.
+     * Defaultnya 7 hari sekali akan dilakukan pembaruan cache.
+     * Gunakan ini jika ingin mengumbah interval sinkronisasinya.
+     *
+     * @param int $interval
+     */
+    public function setInterval($interval)
+    {
+        $interval = (int) $interval;
+        $this->interval = $interval * 86400; // N * 86400 detik (1 hari)
+
+        return $this;
+    }
+
+    /**
+     * Set lokasi folder cache.
+     * Misalkan diisi 'desa/config' maka file cache akan
+     * disimpan di [FCPATH]/desa/config/version.json
+     * Jika folder tidak ditemuakan atau tidak writable
+     * maka akan fallback ke path default (FCPATH/version.json)
+     *
+     * @param string $folder
+     */
+    public function setCacheFolder($folder)
+    {
+        $folder = ltrim($folder, FCPATH);
+        $folder = ltrim($folder, ltrim($folder, '/'), '\\');
+        $folder = rtrim($folder, rtrim($folder, '/'), '\\');
+        $folder = str_replace(array('\\', '/'), DIRECTORY_SEPARATOR, $folder);
+
+        if (! is_dir($folder) || ! is_writable($folder)) {
+            $folder = FCPATH;
+        } else {
+            $folder = FCPATH.DIRECTORY_SEPARATOR.$folder;
+        }
+
+        $this->cache = $folder.DIRECTORY_SEPARATOR.'version.json';
+
+        return $this;
+    }
+
+    /**
+     * Cek apakah ada rilis baru atau tidak.
+     * Caranya dengan membandingkan versi saat ini dengan versi yang ada di repositori.
+     *
+     * @return bool
+     */
+    public function isAvailable()
+    {
+        $current = $this->fixVersioning($this->getCurrentVersion());
+        $latest = $this->fixVersioning($this->getLatestVersion());
+
+        return $current < $latest;
+    }
+
+    /**
+     * Ambil versi rilis saat ini igunakan user.
+     * Contoh return value: 'v20.06-parsca'
+     *
+     * @return string
+     */
+    public function getCurrentVersion()
+    {
+        return 'v'.ltrim(VERSION, 'v');
+    }
+
+    /**
+     * Ambil tag versi dari rilis terbaru.
+     * Contoh return value: 'v20.07'
+     *
+     * @return string
+     */
+    public function getLatestVersion()
+    {
+        return $this->resyncWithOfficialRepository()->tag_name;
+    }
+
+    /**
+     * Ambil nama rilis
+     * Contoh return value di rilis v20.07:
+     *  'Sediakan QR Code dan masukkan APBDes secara manual'
+     * @return string
+     */
+    public function getReleaseName()
+    {
+        return $this->resyncWithOfficialRepository()->name;
+    }
+
+    /**
+     * Ambil deskripsi rilis (github menamainya body).
+     * Contoh return value di rilis v20.07:
+     * 'Di rilis ini, versi 20.07, tersedia fitur untuk membuat file QR Code yg bisa dipasang di artikel,
+     * surat atau materi lain. Rilis ini juga berisi perbaikan lain yang diminta Komunitas SID ... dst.'
+     *
+     * @return string
+     */
+    public function getReleaseBody()
+    {
+        return $this->resyncWithOfficialRepository()->body;
+    }
+
+    /**
+     * Sinkronisasi file cache dengan data di repositori.
+     *
+     * @return array
+     */
+    public function resyncWithOfficialRepository()
+    {
+        if ($this->cacheIsOutdated()) {
+            \Esyede\Curly::$certificate = FCPATH.'/cacert.pem';
+            $response = \Esyede\Curly::get($this->api);
+
+            if ($response instanceof \stdClass) {
+                $response = [
+                    'tag_name' => $response->body->tag_name,
+                    'name' => $response->body->name,
+                    'zipball_url' => $response->body->zipball_url,
+                    'tarball_url' => $response->body->tarball_url,
+                    'body' => $response->body->body,
+                    'created_at' => $response->body->created_at,
+                    'published_at' => $response->body->published_at,
+
+                ];
+
+                $this->writeCache(json_encode($response));
+            }
+        }
+
+        return json_decode(file_get_contents($this->cache));
+    }
+
+    /**
+     * Cek apakah data cache sudah kadaluwarsa atau belum.
+     * Cache dianggap kadaluwarsa jika:
+     *   - File cachenya belum ada di server kita, atau
+     *   - File cache sudah ada tetapi waktu creation-time filenya sudah
+     *     lebih dari interval yang ditentukan.
+     *
+     * @return bool
+     */
+    public function cacheIsOutdated()
+    {
+        $file = $this->cache;
+        $interval = $this->interval;
+
+        return ! is_file($file) || (is_file($file) && time() - filectime($file) < $interval);
+    }
+
+    /**
+     * Ubah versi rilis menjadi integer agar bisa dibandingkan
+     *
+     * @param  string $version
+     *
+     * @return int
+     */
+    public function fixVersioning($version)
+    {
+        $version = preg_replace('/[^0-9.]/', '', $version); // 'v20.07-pasca' -> '20.07'
+        $version = str_replace('.', '0', $version); // '20.07' -> '20007'
+        $version = (int) $version; // 20007 (integer)
+
+        return $version;
+    }
+
+    /**
+     * Buat/timpa file cache jika sudah kadaluwarsa.
+     *
+     * @param  string $cache
+     *
+     * @return void
+     */
+    public function writeCache($cache)
+    {
+        $file = $this->cache;
+        $interval = $this->interval;
+
+        if ($this->cacheIsOutdated()) {
+            if (is_file($file)) {
+                unlink($file);
+            }
+
+            file_put_contents($file, $cache, LOCK_EX);
+        }
+    }
+}

--- a/donjo-app/libraries/Release.php
+++ b/donjo-app/libraries/Release.php
@@ -159,7 +159,7 @@ class Release
 
             $options = array(CURLOPT_HTTPHEADER => array('Accept' => 'application/vnd.github.v3+json'));
 
-            $response = \Esyede\Curly::get($this->api, [], $options);
+            $response = \Esyede\Curly::get($this->api, array(), $options);
 
             if ($response instanceof \stdClass) {
                 $response = [

--- a/donjo-app/views/home/desa.php
+++ b/donjo-app/views/home/desa.php
@@ -13,6 +13,24 @@
 	</section>
 	<section class='content' id="maincontent">
 		<div class='row'>
+			<?php if ($update_available): ?>
+				<div class='col-md-12'>
+					<div class="callout callout-danger update">
+						<h4><i class="fa fa-info-circle"></i> Update Tersedia!</h4>
+						<p>
+							OpenSID versi <code><?php echo $latest_version ?></code> telah tersedia, versi yang anda gunakan saat ini <code><?php echo $current_version ?></code> mungkin mengandung celah keamanan yang pelu ditutup. Silahakan baca catatan rilis dan segera update sekarang juga.
+							<br>
+							<a href="https://github.com/OpenSID/OpenSID/archive/<?php echo $latest_version ?>.zip" class="btn btn-flat btn-success btn-sm pull-right" style="text-decoration: none">
+								<i class="fa fa-download"></i> Download
+							</a>
+							<a href="https://github.com/OpenSID/OpenSID/releases/tag/<?php echo $latest_version ?>" class="btn btn-flat btn-info btn-sm pull-right" style="text-decoration: none">
+								<i class="fa fa-github"></i> Catatan Rilis
+							</a>
+							<br>
+						</p>
+					</div>
+				</div>
+			<?php endif; ?>
 			<div class='col-md-6'>
 				<div class='box box-info'>
 				 	<div class='box-body'>


### PR DESCRIPTION
Solusi untuk fitur notifikasi update terkait issue #3202 #3204


### Cara Kerja:
  1. Saat pertama kali dijalankan, script akan mengunduh CA bundle agar bisa terkoneksi ke github via TLS. File CA bundle disimpan di root directory dengan nama `cacert.pem`. Request ini hanya dijalankan sekali saja, yaitu ketika file `cacert.pem` belum ada.
  2. Script melakukan request ke github release api untuk mengambil data rilis terbaru jika file `version.json` belum ada atau filenya sudah kadaluwarsa. [1]
  3. Data-data request disimpan ke file `version.json` tadi.
  4. Jika file `version.json` belum kadaluwarsa, script hanya akan membaca data dari file `version.json` saja. Tidak akan melakukan request berulang.
  5. Waktu kadaluwarsa defaultnya adalah 7 hari[2] terhitung sejak request di poin ke-2 dijalankan.
  6. Jika file `version.json` sudah kadaluwarsa maka script akan melakukan request ulang ke github dan menimpa isinya dengan yang baru.


### Cara Testing:
  1. Ubah constant `VERSION` di file `donjo-app/helpers/opensid_helper.php` ke versi yang lebih rendah dari versi saat ini.
  2. Kunjungi halaman dashboard admin
  3. Akan ditampilkan callout alert untuk update jika versi saat ini lebih rendah dari versi di repo.
  4. Hapus file `version.json` yang ada di root directory untuk mencoba lagi.


[1] File dianggap kadaluwarsa jika filenya tidak ditemukan atau waktu modifikasi terakhir filenya lebih tua dari waktu kadaluwarsa yang ditentukan. Pengecekannya memanfatkan fungsi [filemtime()](https://www.php.net/manual/en/function.filemtime.php)
[2] Apakah interval 7 hari sudah cukup ideal?