### PR TITLE
Tambahkan bantuan yg diterima pd calon penerima bantuan

### DIFF
--- a/donjo-app/controllers/Program_bantuan.php
+++ b/donjo-app/controllers/Program_bantuan.php
@@ -1,4 +1,6 @@
-<?php if (!defined('BASEPATH')) exit('No direct script access allowed');
+<?php
+
+defined('BASEPATH') OR exit('No direct script access allowed');
 
 class Program_bantuan extends Admin_Controller {
 
@@ -38,9 +40,7 @@ class Program_bantuan extends Admin_Controller {
 		$data = $this->program_bantuan_model->get_program($p, FALSE);
 		$data['tampil'] = 0;
 		$data['list_sasaran'] = unserialize(SASARAN);
-		$data['p'] = $p;
 		$data['func'] = 'index';
-		$data['per_page'] = $this->session->per_page;
 		$data['set_page'] = $this->_set_page;
 
 		$this->load->view('header', $this->_header);

--- a/donjo-app/models/Program_bantuan_model.php
+++ b/donjo-app/models/Program_bantuan_model.php
@@ -107,7 +107,7 @@ class Program_bantuan_model extends MY_Model {
 
 		$this->load->library('paging');
 		$cfg['page'] = $p;
-		$cfg['per_page'] = $_SESSION['per_page'];
+		$cfg['per_page'] = $this->session->per_page;
 		$cfg['num_rows'] = $jml_data;
 		$this->paging->init($cfg);
 
@@ -169,6 +169,8 @@ class Program_bantuan_model extends MY_Model {
 			default:
 				break;
 		}
+
+		$data['program'] = $this->program_bantuan_model->get_peserta_program($sasaran, $data['kartu_nik']);
 
 		return $data;
 	}
@@ -707,7 +709,7 @@ class Program_bantuan_model extends MY_Model {
 		 * $cat => $sasaran adalah tipe/kategori si $id.
 		 *
 		 * */
-		$strSQL = "SELECT p.id AS id, o.peserta AS nik, o.id AS peserta_id,  p.nama AS nama, p.sdate, p.edate, p.ndesc
+		$strSQL = "SELECT p.id AS id, o.peserta AS nik, o.id AS peserta_id,  p.nama AS nama, p.sdate, p.edate, p.ndesc, p.status
 			FROM program_peserta o
 			LEFT JOIN program p ON p.id = o.program_id
 			WHERE ((o.peserta='".fixSQL($id)."') AND (p.sasaran='".fixSQL($cat)."'))";

--- a/donjo-app/views/program_bantuan/konfirmasi_peserta.php
+++ b/donjo-app/views/program_bantuan/konfirmasi_peserta.php
@@ -11,24 +11,24 @@
 	</div>
 </div>
 <?php if ($detail["sasaran"] == 2): ?>
-<div class="form-group">
-	<label class="col-sm-4 col-lg-3 control-label">Nomer KK</label>
-	<div class="col-sm-7">
-		<input class="form-control input-sm" type="text" disabled value="<?= $individu['no_kk'];?>">
+	<div class="form-group">
+		<label class="col-sm-4 col-lg-3 control-label">Nomer KK</label>
+		<div class="col-sm-7">
+			<input class="form-control input-sm" type="text" disabled value="<?= $individu['no_kk'];?>">
+		</div>
 	</div>
-</div>
-<div class="form-group">
-	<label class="col-sm-4 col-lg-3 control-label">Nama Kepala Keluarga</label>
-	<div class="col-sm-7">
-		<input class="form-control input-sm" type="text" disabled value="<?= $individu['nama_kk'];?>">
+	<div class="form-group">
+		<label class="col-sm-4 col-lg-3 control-label">Nama Kepala Keluarga</label>
+		<div class="col-sm-7">
+			<input class="form-control input-sm" type="text" disabled value="<?= $individu['nama_kk'];?>">
+		</div>
 	</div>
-</div>
-<div class="form-group">
-	<label class="col-sm-4 col-lg-3 control-label">Status KK</label>
-	<div class="col-sm-7">
-		<input class="form-control input-sm" type="text" disabled value="<?= $individu['hubungan'];?>">
+	<div class="form-group">
+		<label class="col-sm-4 col-lg-3 control-label">Status KK</label>
+		<div class="col-sm-7">
+			<input class="form-control input-sm" type="text" disabled value="<?= $individu['hubungan'];?>">
+		</div>
 	</div>
-</div>
 <?php endif; ?>
 <div class="form-group">
 	<label class="col-sm-4 col-lg-3 control-label">Alamat <?=$individu['judul']?></label>
@@ -58,5 +58,15 @@
 	<label class="col-sm-4 col-lg-3 control-label">Warga Negara / Agama <?=$individu['judul']?></label>
 	<div class="col-sm-7">
 		<input class="form-control input-sm" type="text" disabled value="<?= $individu['warganegara']?> / <?= $individu['agama']?>">
+	</div>
+</div>
+<div class="form-group">
+	<label class="col-sm-4 col-lg-3 control-label">Bantuan <?=$individu['judul']?> Yang Sedang Diterima</label>
+	<div class="col-sm-7">
+		<?php foreach ($individu['program']['programkerja'] as $item): ?>
+			<?php if($item[status] == '1'): ?>
+				<a href="<?= site_url("program_bantuan/data_peserta/$item[peserta_id]")?>" target="_blank"><span class="label label-success"><?= $item['nama']?></span>&nbsp;</a>
+			<?php endif; ?>
+		<?php endforeach; ?>
 	</div>
 </div>


### PR DESCRIPTION
Solusi untuk {perbaikan|fitur baru} terkait issue #3313

Untuk saat ini sy buat agar panitia yg melakukan verifikasi manual dgn melihat bantuan aktif yg diterima oleh penduduk/kk/rtm/kelompok tsb.

Hanya menampilkan info bantuan yg aktif:
![bantuan](https://user-images.githubusercontent.com/57283157/87136520-d1a7c380-c2c5-11ea-8018-1b46c493c5be.JPG)

Dan kyaknya perlu diperbaiki fuction yg ada di model program bantuan.