### PR TITLE
Ubah cara menampilkan notifikasi pengumuman

### DIFF
--- a/donjo-app/core/MY_Controller.php
+++ b/donjo-app/core/MY_Controller.php
@@ -218,12 +218,23 @@ class Admin_Controller extends MY_Controller
 	private function cek_pengumuman()
 	{
 		if ($this->grup == 1) // hanya utk user administrator
-		{
-			// Cek persetujuan_penggunaan terlebih dahulu
-			$this->pengumuman = $this->notif_model->notifikasi('persetujuan_penggunaan');
-			if($this->pengumuman == NULL && $this->setting->enable_track == 0)
+		{			
+			$notifikasi = $this->notif_model->get_semua_notif();
+			foreach($notifikasi as $notif)
 			{
-				$this->pengumuman = $this->notif_model->notifikasi('tracking_off');
+				switch ($notif['kode']) 
+				{
+					case 'persetujuan_penggunaan':
+						$this->pengumuman = $this->notif_model->notifikasi('persetujuan_penggunaan');
+						break 2;  // keluar dari switch dan foreach 
+					case 'tracking_off':
+						if($this->setting->enable_track == 0)
+							$this->pengumuman = $this->notif_model->notifikasi('tracking_off');
+						break 2;
+					default:
+						$this->pengumuman = $this->notif_model->notifikasi($notif['kode']);
+						break 2;
+				}
 			}
 		}
 

--- a/donjo-app/models/Notif_model.php
+++ b/donjo-app/models/Notif_model.php
@@ -92,6 +92,18 @@ class Notif_model extends CI_Model {
 		$this->notif_model->update_by_kode($kode, $tgl_berikutnya, $tgl_sekarang, $user);
 	}
 
+	// query semua notifikasi yang siap untuk tampil
+	// order by 'id' dengan asumsi id=1 adalah Persetujuan Penggunaan 
+	public function get_semua_notif()
+	{
+		$hari_ini = new DateTime();
+		$compare = $hari_ini->format('Y-m-d H:i:s');
+		$semua_notif = $this->db->where('tgl_berikutnya <=', $compare)
+								->order_by('id', 'ASC')
+								->get('notifikasi')->result_array();
+		return $semua_notif;
+	}
+
 }
 
 ?>

--- a/donjo-app/models/Notif_model.php
+++ b/donjo-app/models/Notif_model.php
@@ -74,7 +74,7 @@ class Notif_model extends CI_Model {
 		$notif = $this->notif_model->get_notif_by_kode($kode);
 		$tgl_sekarang = date("Y-m-d H:i:s");
 
-		if (empty($this->input->post('cek_lagi')))
+		if (!empty($this->input->post('cek_lagi'))) /// jika checkbox 'jangan tampilkan lagi' dicentang
 		{
 			$frekuensi = $notif['frekuensi'];
 			$string_frekuensi = "+". $frekuensi . " Days";

--- a/donjo-app/models/Notif_model.php
+++ b/donjo-app/models/Notif_model.php
@@ -58,6 +58,7 @@ class Notif_model extends CI_Model {
 		{
 			// simpan view pengumuman dalam variabel
 			$data['isi_pengumuman'] = $notif['isi'];
+			$data['kode'] = $notif['kode'];
 			$data['judul'] = $notif['judul'];
 			$data['aksi'] = $notif['aksi'];
 			$aksi = explode(',', $notif['aksi']);
@@ -74,16 +75,18 @@ class Notif_model extends CI_Model {
 		$notif = $this->notif_model->get_notif_by_kode($kode);
 		$tgl_sekarang = date("Y-m-d H:i:s");
 
-		if (!empty($this->input->post('cek_lagi'))) /// jika checkbox 'jangan tampilkan lagi' dicentang
+		// jika notifikasi berupa pemberitahuan tracking, dan checkbox jangan tampilkan lagi tidak dicentang
+		// maka notifikasi akan ditampilkan lagi
+		if (empty($this->input->post('cek_lagi')) && $kode == 'tracking_off' ) 
+		{
+			$tgl_berikutnya = $tgl_sekarang;
+		}
+		else
 		{
 			$frekuensi = $notif['frekuensi'];
 			$string_frekuensi = "+". $frekuensi . " Days";
 			$tambah_hari = strtotime($string_frekuensi); // tgl hari ini ditambah frekuensi
-			$tgl_berikutnya =  date('Y-m-d H:i:s', $tambah_hari);
-		}
-		else
-		{
-			$tgl_berikutnya = $tgl_sekarang;
+			$tgl_berikutnya =  date('Y-m-d H:i:s', $tambah_hari);			
 		}
 		$user = $this->session->user;
 		$this->notif_model->update_by_kode($kode, $tgl_berikutnya, $tgl_sekarang, $user);

--- a/donjo-app/views/notif/pengumuman.php
+++ b/donjo-app/views/notif/pengumuman.php
@@ -17,7 +17,8 @@
 					<?php endif ?>
 				</div>
 				<center>
-					<i id="indikator" class="fa fa-spinner fa-spin fa-3x fa-fw"></i>
+				<div id="indikator" class='text-center'>
+					<img src='<?= base_url()?>assets/images/background/loading.gif'>
 				</center>
 			</div>
 			<div class='modal-footer' id='m_footer'> 

--- a/donjo-app/views/notif/pengumuman.php
+++ b/donjo-app/views/notif/pengumuman.php
@@ -1,3 +1,4 @@
+<form id="form-pengumuman" method="POST">
 <div class="modal fade" id="pengumuman" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
 	<div class='modal-dialog'>
 		<div class='modal-content'>
@@ -18,12 +19,15 @@
 				</center>
 			</div>
 			<div class='modal-footer' id='m_footer'>
-				<button <?= ($kode=='tracking_off') ? 'type="reset" data-dismiss="modal"' : 'id="btnTidak"';?> class="btn btn-social btn-flat btn-danger btn-sm"><i class='fa fa-sign-out'></i> Tidak</button>
-				<button id="btnSetuju" type="button" class="btn btn-social btn-flat btn-warning btn-sm"><i class='fa fa-check'></i> Setuju</button>
+				<button <?= ($kode=='tracking_off') ? 'type="submit" data-dismiss="modal"' : 'id="btnTidak"';?> class="btn btn-social btn-flat btn-danger btn-sm"><i class='fa fa-sign-out'></i> Tidak</button>
+				<button  type="submit" id="btnSetuju" class="btn btn-social btn-flat btn-warning btn-sm"><i class='fa fa-check'></i> Setuju</button>
 			</div>
 		</div>
 	</div>
 </div>
+</form>
+
+
 <script type="text/javascript">
 	$('document').ready(function() {
 		$('#pengumuman').modal({backdrop: 'static', keyboard: false});
@@ -39,6 +43,7 @@
 		$.ajax({
 			type: "POST",
 			url: SITE_URL + "<?= $aksi_ya; ?>",
+            data: $('#form-pengumuman').serialize(),
 			success: function() {
 				$('#indikator').hide();
 				$('#pengumuman').modal('hide');
@@ -50,4 +55,5 @@
 	$('#btnTidak').on('click', function() {
 		location.href = SITE_URL + "<?= $aksi_tidak; ?>";
 	});
+	// TODO ketika button tidak diklik dan checkbox dicentang, maka pake ajax otherwise cancel biasa
 </script>

--- a/donjo-app/views/notif/pengumuman.php
+++ b/donjo-app/views/notif/pengumuman.php
@@ -8,18 +8,20 @@
 			<div class='modal-body'>
 				<div id="isi">
 					<?= $isi_pengumuman; ?>
+					<?php if ($kode=='tracking_off'): ?>
 					<div class="checkbox">
 						<label>
-							<input type="checkbox" name="cek_lagi" value="cek_lagi"></input>&nbsp;Jangan tampilkan lagi
+							<input type="checkbox" id="cek_lagi" name="cek_lagi" value="cek_lagi"></input>&nbsp;Jangan tampilkan lagi
 						</label>
 					</div>
+					<?php endif ?>
 				</div>
 				<center>
 					<i id="indikator" class="fa fa-spinner fa-spin fa-3x fa-fw"></i>
 				</center>
 			</div>
-			<div class='modal-footer' id='m_footer'>
-				<button <?= ($kode=='tracking_off') ? 'type="submit" data-dismiss="modal"' : 'id="btnTidak"';?> class="btn btn-social btn-flat btn-danger btn-sm"><i class='fa fa-sign-out'></i> Tidak</button>
+			<div class='modal-footer' id='m_footer'> 
+				<button type="reset" data-dismiss="modal" id="btnTidak" class="btn btn-social btn-flat btn-danger btn-sm"><i class='fa fa-sign-out'></i> Tidak</button>
 				<button  type="submit" id="btnSetuju" class="btn btn-social btn-flat btn-warning btn-sm"><i class='fa fa-check'></i> Setuju</button>
 			</div>
 		</div>
@@ -52,8 +54,29 @@
 		return false;
 	});
 
+	// ketika ada checkbox dan dicentang, maka pake ajax (submit form) otherwise button cancel biasa
 	$('#btnTidak').on('click', function() {
-		location.href = SITE_URL + "<?= $aksi_tidak; ?>";
+		if(document.querySelector('#cek_lagi:checked') !== null)
+		{
+			$('#isi').hide();
+			$('#m_footer').hide();
+			$('#indikator').show();
+			$('#btnSetuju').prop('disabled', true);
+			$('#btnTidak').prop('disabled', true);
+			$.ajax({
+				type: "POST",
+				url: SITE_URL + "<?= $aksi_tidak; ?>",
+				data: $('#form-pengumuman').serialize(),
+				success: function() {
+					$('#indikator').hide();
+					$('#pengumuman').modal('hide');
+				}
+			});
+			return false;
+		}
+		else
+		{
+			location.href = SITE_URL + "<?= $aksi_tidak; ?>";
+		}		
 	});
-	// TODO ketika button tidak diklik dan checkbox dicentang, maka pake ajax otherwise cancel biasa
 </script>


### PR DESCRIPTION
Solusi untuk perbaikan terkait issue #3205 #3206 

Catatan:
1. Notifikasi ditampilkan secara bergantian tapi masih memerlukan refresh atau pindah halaman. 
2. Semua notifikasi yang siap tayang selalu dicek di awal. Prioritas utama notifikasi yang tampil adalah "**Persetujuan Penggunaan**" dengan asumsi akan diinput di tabel dengan id=1
3. Pada window notifikasi **tracking** terdapat tombol "Setuju" dan "Tidak" serta checkbox "Jangan tampilkan lagi". Jika user klik tombol "Tidak" dan centang checkbox, maka notifikasi tidak akan ditampilkan selama periode seusai "frekuensi" dalam database.

NB:
Mohon maaf ada commit yang seharusnya ngga perlu diikutkan. Saya sering berpindah antara komputer kantor dan rumah, jadi perubahan sementara terkadang saya commit juga untuk sinkronisasi di kantor dan di rumah.
