### PR TITLE
Fungsi Notifikasi Terpanggil Jika Sudah Migrasi DB

### DIFF
--- a/donjo-app/core/MY_Controller.php
+++ b/donjo-app/core/MY_Controller.php
@@ -214,7 +214,7 @@ class Admin_Controller extends MY_Controller {
 		parent::__construct();
 		$this->CI = CI_Controller::get_instance();
 		$this->controller = strtolower($this->router->fetch_class());
-		$this->load->model(['user_model', 'notif_model']);
+		$this->load->model(['user_model', 'notif_model', 'database_model']);
 		$this->grup	= $this->user_model->sesi_grup($_SESSION['sesi']);
 
 		$this->load->model('modul_model');
@@ -243,6 +243,7 @@ class Admin_Controller extends MY_Controller {
 
 	private function cek_pengumuman()
 	{
+		$this->database_model->migrasi_db_cri();
 		if ($this->grup == 1) // hanya utk user administrator
 		{
 			$notifikasi = $this->notif_model->get_semua_notif();


### PR DESCRIPTION
Ketika upgrade release dari 20.07 ke 20.08 kemudian melakukan login dan lanjut ke hom_sid, fungsi Notifikasi sudah terpanggil walaupun tabel notifikasi belum tersedia sehingga akan keluar warning error 500, maka perlu penyesuaian db terlebih dahulu di my_controller.
Hal ini tidak akan terjadi untuk yg upgrade dengan mengikuti setiap perubahan di master (20.07 pasca), tapi hanya terjadi pada upgrade rilis 20.07 langsung ke 20.08.
