### PR TITLE
Perbaiki migrasi dapat dijalankan berulang kali

### DIFF
--- a/donjo-app/models/migrations/Migrasi_2008_ke_2009.php
+++ b/donjo-app/models/migrations/Migrasi_2008_ke_2009.php
@@ -91,7 +91,7 @@ class Migrasi_2008_ke_2009 extends CI_model {
 		// Hapus anggota kelompok yg tdk memiliki kelompok / tdk terhapus saat menghapus kelompok
 		$kelompok = $this->db->select('id')->get('kelompok')->result_array();
 		$list_id_kelompok = sql_in_list(array_column($kelompok, 'id'));
-		$this->db->where("id_kelompok NOT IN ($list_id_kelompok)")->delete('kelompok_anggota');
+		if ($list_id_kelompok) $this->db->where("id_kelompok NOT IN ($list_id_kelompok)")->delete('kelompok_anggota');
 		// Buat FOREIGN KEY field id_kelompok jika tdk ada
 		$query = $this->db
 			->from('INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS')


### PR DESCRIPTION
Setelah melakukan pengecekan ulang untuk PR #3486 yg sdah dimeger, terjadi error migrasi yg dijalankan berulang krn variable dalam list_id_kelompok kosong. Jd PR ini sebagai tambalan sj.