### PR TITLE
 perbaikan: penangguhan akses login berdasarkan alamat IP

### DIFF
--- a/donjo-app/config/constants.php
+++ b/donjo-app/config/constants.php
@@ -83,3 +83,14 @@ defined('EXIT_USER_INPUT')     OR define('EXIT_USER_INPUT', 7); // invalid user 
 defined('EXIT_DATABASE')       OR define('EXIT_DATABASE', 8); // database error
 defined('EXIT__AUTO_MIN')      OR define('EXIT__AUTO_MIN', 9); // lowest automatically-assigned error code
 defined('EXIT__AUTO_MAX')      OR define('EXIT__AUTO_MAX', 125); // highest automatically-assigned error code
+
+/**
+ * --------------------------------------------------------
+ * KONSTANTA TAMBAHAN
+ * --------------------------------------------------------
+ */
+// Masa tunggu jika telah melebihi batas percobaan login (dalam satuan detik)
+defined('DURASI_BLOKIR_SITEMAN') OR define('DURASI_BLOKIR_SITEMAN', 300);
+// Batas maksimum percobaan login
+defined('MAX_PERCOBAAN_SITEMAN') OR define('MAX_PERCOBAAN_SITEMAN', 3);
+

--- a/donjo-app/controllers/Database.php
+++ b/donjo-app/controllers/Database.php
@@ -72,7 +72,6 @@ class Database extends Admin_Controller {
 			log_message('debug', "Reset tracking");
 			unset($_SESSION['track_web']);
 			unset($_SESSION['track_admin']);
-			unset($_SESSION['siteman_timeout']);
 		}
 
 		$data['act_tab'] = 1;

--- a/donjo-app/controllers/Siteman.php
+++ b/donjo-app/controllers/Siteman.php
@@ -42,6 +42,7 @@
 
 class Siteman extends CI_Controller
 {
+	private $ip_address;
 
 	private $ip_address;
 
@@ -49,6 +50,7 @@ class Siteman extends CI_Controller
 	{
 		parent::__construct();
 		$this->load->model(array('config_model', 'user_model', 'log_siteman_model'));
+
 	}
 
 	public function index()

--- a/donjo-app/helpers/donjolib_helper.php
+++ b/donjo-app/helpers/donjolib_helper.php
@@ -374,23 +374,6 @@ function mandiri_timeout(){
 	}
 }
 
-//time out Admin set 3 login per 5 menit
-function siteman_timer()
-{
-	$time = 300;  //300 detik
-	$_SESSION['siteman_try'] = 4;
-	$_SESSION['siteman_timeout'] = time() + $time;
-}
-
-function siteman_timeout()
-{
-	$timeout = (isset($_SESSION['siteman_timeout'])) ? $_SESSION['siteman_timeout'] : null;
-	if (time() > $timeout)
-	{
-		$_SESSION['siteman_wait'] = 0;
-	}
-}
-
 function get_identitas()
 {
 	$ci =& get_instance();

--- a/donjo-app/helpers/opensid_helper.php
+++ b/donjo-app/helpers/opensid_helper.php
@@ -1061,3 +1061,7 @@ function crawler()
 
 	return FALSE;
 }
+
+function get_ip_address() {
+	return getenv('HTTP_X_FORWARDED_FOR') ? getenv('HTTP_X_FORWARDED_FOR') : getenv('REMOTE_ADDR');
+}

--- a/donjo-app/models/Log_siteman_model.php
+++ b/donjo-app/models/Log_siteman_model.php
@@ -1,0 +1,114 @@
+<?php
+
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+/**
+ * File ini:
+ *
+ * Model untuk halaman siteman
+ *
+ * donjo-app/models/Log_siteman_model.php,
+ *
+ */
+
+/**
+ *
+ * File ini bagian dari:
+ *
+ * OpenSID
+ *
+ * Sistem informasi desa sumber terbuka untuk memajukan desa
+ *
+ * Aplikasi dan source code ini dirilis berdasarkan lisensi GPL V3
+ *
+ * Hak Cipta 2009 - 2015 Combine Resource Institution (http://lumbungkomunitas.net/)
+ * Hak Cipta 2016 - 2020 Perkumpulan Desa Digital Terbuka (https://opendesa.id)
+ *
+ * Dengan ini diberikan izin, secara gratis, kepada siapa pun yang mendapatkan salinan
+ * dari perangkat lunak ini dan file dokumentasi terkait ("Aplikasi Ini"), untuk diperlakukan
+ * tanpa batasan, termasuk hak untuk menggunakan, menyalin, mengubah dan/atau mendistribusikan,
+ * asal tunduk pada syarat berikut:
+ *
+ * Pemberitahuan hak cipta di atas dan pemberitahuan izin ini harus disertakan dalam
+ * setiap salinan atau bagian penting Aplikasi Ini. Barang siapa yang menghapus atau menghilangkan
+ * pemberitahuan ini melanggar ketentuan lisensi Aplikasi Ini.
+ *
+ * PERANGKAT LUNAK INI DISEDIAKAN "SEBAGAIMANA ADANYA", TANPA JAMINAN APA PUN, BAIK TERSURAT MAUPUN
+ * TERSIRAT. PENULIS ATAU PEMEGANG HAK CIPTA SAMA SEKALI TIDAK BERTANGGUNG JAWAB ATAS KLAIM, KERUSAKAN ATAU
+ * KEWAJIBAN APAPUN ATAS PENGGUNAAN ATAU LAINNYA TERKAIT APLIKASI INI.
+ *
+ * @package	OpenSID
+ * @author	Tim Pengembang OpenDesa
+ * @copyright	Hak Cipta 2009 - 2015 Combine Resource Institution (http://lumbungkomunitas.net/)
+ * @copyright	Hak Cipta 2016 - 2020 Perkumpulan Desa Digital Terbuka (https://opendesa.id)
+ * @license	http://www.gnu.org/licenses/gpl.html	GPL V3
+ * @link 	https://github.com/OpenSID/OpenSID
+ */
+
+ class Log_siteman_model extends CI_Model 
+ {
+	 public static $tabel = 'log_siteman';
+
+	 public function __construct() {
+		 parent::__construct();
+	 }
+
+	 public function ambil_log_ip($ip_address)
+	 {
+		 $query = $this->db->where('ip_address', $ip_address)->get(self::$tabel);
+		 if ($query->num_rows() === 1) 
+		 {
+			 return $query->row();
+		 }
+		 return NULL;
+	 }
+
+	 public function cek_blokir($ip_address)
+	 {
+		 $max_percobaan = MAX_PERCOBAAN_SITEMAN;
+		 $durasi_blokir = DURASI_BLOKIR_SITEMAN;
+		 $log_ip = $this->ambil_log_ip($ip_address);
+		 if (is_object($log_ip) && $log_ip->counter >= $max_percobaan) 
+		 {
+				$percobaan_terakhir = strtotime($log_ip->updated_at);
+				$masa_tenggang = time() - $percobaan_terakhir;
+
+				if ($masa_tenggang >= $durasi_blokir) 
+				{
+					$this->reset_log_ip($ip_address);
+					return false;
+				}
+				return true;
+		 }
+		 return false;
+	 }
+
+	 public function update_log_ip($ip_address) 
+	 {
+		 $log_ip = $this->ambil_log_ip($ip_address);
+		 if ($log_ip) 
+		 {
+			 $update_entri = array(
+				 'counter' => $log_ip->counter + 1,
+				 'updated_at' => date('Y-m-d H:i:s')
+			 );
+			 $this->db->where('ip_address', $ip_address)->update(self::$tabel, $update_entri);
+		 }
+		 else 
+		 {
+			 $entri_baru = array(
+				'created_at' => date('Y-m-d H:i:s'),
+				'updated_at' => date('Y-m-d H:i:s'),
+				'ip_address' => $ip_address,
+				'counter' => 1
+			 );
+			 $this->db->insert(self::$tabel, $entri_baru);
+		 }
+	 }
+
+	 public function reset_log_ip($ip_address)
+	 {
+		 return $this->db->where('ip_address', $ip_address)->delete(self::$tabel);
+	 }
+ }
+ 

--- a/donjo-app/models/User_model.php
+++ b/donjo-app/models/User_model.php
@@ -67,7 +67,7 @@ class User_model extends CI_Model {
 			'allowed_types' => 'gif|jpg|jpeg|png',
 			'max_size' => max_upload()*1024,
 		);
-		$this->load->model('laporan_bulanan_model');
+		$this->load->model(array('laporan_bulanan_model', 'log_siteman_model'));
 		// Untuk password hashing
 		$this->load->helper('password');
         // Helper upload file
@@ -105,17 +105,9 @@ class User_model extends CI_Model {
 		// Login gagal: user tidak ada atau tidak lolos verifikasi
 		if ($userAda === FALSE || $authLolos === FALSE)
 		{
-			$_SESSION['siteman'] = -1;
-			if ($_SESSION['siteman_try'] > 2)
-			{
-				$_SESSION['siteman_try'] = $_SESSION['siteman_try']-1;
-			}
-			else
-			{
-				$_SESSION['siteman_wait'] = 1;
-				unset($_SESSION['siteman_timeout']);
-				siteman_timer();
-			}
+			$ip_address = get_ip_address();
+			$this->log_siteman_model->update_log_ip($ip_address);
+			$this->session->set_userdata('siteman', -1);
 		}
 		// Login sukses: ubah pass di db ke bcrypt jika masih md5 dan set session
 		else

--- a/donjo-app/models/migrations/Migrasi_2009_ke_2010.php
+++ b/donjo-app/models/migrations/Migrasi_2009_ke_2010.php
@@ -60,7 +60,27 @@ class Migrasi_2009_ke_2010 extends MY_model {
 							keterangan = VALUES(keterangan)
 							");
 		$hasil =& $this->db->query('ALTER TABLE tweb_desa_pamong MODIFY COLUMN pamong_niap varchar(25) default 0');
+
+		$hasil =& $this->add_log_siteman();
+
 		status_sukses($hasil);
+	}
+
+	private function add_log_siteman()
+	{
+		if (!$this->db->table_exists('log_siteman'))
+		{
+			$query = "
+				CREATE TABLE `log_siteman`(
+					`id` int(11) NOT NULL AUTO_INCREMENT,
+					`ip_address` varchar(45),
+					`counter` int(11) DEFAULT 1,
+					`created_at` DATETIME,
+					`updated_at` DATETIME,
+					PRIMARY KEY (id)
+				)";
+			$this->db->query($query);
+		}
 	}
 
 }

--- a/donjo-app/views/siteman.php
+++ b/donjo-app/views/siteman.php
@@ -90,8 +90,8 @@
 								<hr />
 							</div>
 							<div class="form-bottom">
-								<form id="validasi" class="login-form" action="<?=site_url('siteman/auth')?>" method="post" >
-									<?php if ($this->session->siteman_wait == 1): ?>
+								<form class="login-form" action="<?=site_url('siteman/auth')?>" method="post" >
+									<?php if ($status_blokir): ?>
 										<div class="error login-footer-top">
 											<p id="countdown" style="color:red; text-transform:uppercase"></p>
 										</div>
@@ -107,14 +107,14 @@
 										</div>
 										<hr />
 										<button type="submit" class="btn">MASUK</button>
-										<?php if ($this->session->siteman == -1 && $this->session->siteman_try < 4): ?>
+										<?php if ($this->session->userdata('siteman') == -1): ?>
 											<div class="error">
 												<p style="color:red; text-transform:uppercase">Login Gagal.<br />Nama pengguna atau kata sandi yang Anda masukkan salah!<br />
 												<?php if ($this->session->siteman_try): ?>
 													Kesempatan mencoba <?= ($this->session->siteman_try - 1); ?> kali lagi.</p>
 												<?php endif; ?>
 											</div>
-										<?php elseif ($this->session->siteman == -2): ?>
+										<?php elseif ($this->session->userdata('siteman') == -2): ?>
 											<div class="error">
 												Redaksi belum boleh masuk, SID belum memiliki sambungan internet!
 											</div>
@@ -132,9 +132,8 @@
 	</body>
 </html>
 <script>
-
-	function start_countdown(){
-		var times = eval(<?= json_encode($this->session->siteman_timeout)?>) - eval(<?= json_encode(time())?>);
+	function start_countdown() {
+		var times = <?= $masa_tunggu ?>;
 		var menit = Math.floor(times / 60);
 		var detik = times % 60;
 		timer = setInterval(function(){
@@ -152,21 +151,18 @@
 		}, 1000)
 	}
 
-	$('document').ready(function()
-	{
+	$('document').ready(function() {
 		var pass = $("#password");
-		$('#checkbox').click(function(){
-			if (pass.attr('type') === "password"){
+		$('#checkbox').click(function() {
+			if (pass.attr('type') === "password") {
 				pass.attr('type', 'text');
 			} else {
 				pass.attr('type', 'password')
 			}
 		});
 
-		if ($('#countdown').length)
-		{
+		if ($('#countdown').length) {
 			start_countdown();
 		}
 	});
-
 </script>

--- a/donjo-app/views/siteman.php
+++ b/donjo-app/views/siteman.php
@@ -97,21 +97,21 @@
 										</div>
 									<?php else: ?>
 										<div class="form-group">
-											<input name="username" type="text" placeholder="Nama pengguna" <?php jecho($this->session->siteman_wait, 1, "disabled") ?> value="" class="form-username form-control required">
+											<input name="username" type="text" placeholder="Nama pengguna" value="" required class="form-username form-control input-error" <?php $status_blokir and print('disabled') ?>>
 										</div>
 										<div class="form-group">
-											<input name="password" id="password" type="password" placeholder="Kata sandi" <?php jecho($this->session->siteman_wait, 1, "disabled") ?> value="" class="form-username form-control required">
+											<input name="password" id="password" type="password" placeholder="Kata sandi" value="" required class="form-username form-control input-error" <?php $status_blokir and print('disabled') ?>>
 										</div>
 										<div class="form-group">
 											<input type="checkbox" id="checkbox" class="form-checkbox"> Tampilkan kata sandi
 										</div>
 										<hr />
-										<button type="submit" class="btn">MASUK</button>
+										<button type="submit" class="btn" <?php $status_blokir and print('disabled') ?>>MASUK</button>
 										<?php if ($this->session->userdata('siteman') == -1): ?>
 											<div class="error">
 												<p style="color:red; text-transform:uppercase">Login Gagal.<br />Nama pengguna atau kata sandi yang Anda masukkan salah!<br />
-												<?php if ($this->session->siteman_try): ?>
-													Kesempatan mencoba <?= ($this->session->siteman_try - 1); ?> kali lagi.</p>
+												<?php if (!$status_blokir): ?>
+													Kesempatan mencoba <?= $sisa_percobaan ?> kali lagi.</p>
 												<?php endif; ?>
 											</div>
 										<?php elseif ($this->session->userdata('siteman') == -2): ?>


### PR DESCRIPTION
Solusi untuk perbaikan terkait issue #3536.
Pendekatan yang dilakukan sementara ini:
- [x] Tambah tabel `log_siteman` untuk pencatatan IP Address.
- [x] Gunakan kolom `counter` pada tabel untuk menghitung berapa kali percobaan telah dilakukan.
- [x] Setelah mencapai batas maksimum percobaan, akses login akan dibekukan. Masa tunggu diberlakukan selama 5 menit.
- [x] Setelah masa tunggu berakhir, record IP Address dihapus dari tabel
- [ ] Migrasi database untuk menambahkan tabel `log_siteman` perlu dilakukan ketika halaman login admin dibuka. (Pendekatan ini belum dilakukan karena saya belum tau caranya)

Perlu diterapkan:
- counter perlu direset jika admin melakukan logout / mengakses halaman siteman pertama kali.
- [dll]