### PR TITLE
Susulan #3617 : Romawi pd Nama Wilayah

### DIFF
--- a/donjo-app/helpers/donjolib_helper.php
+++ b/donjo-app/helpers/donjolib_helper.php
@@ -603,8 +603,15 @@ function ribuan($angka)
 // Kalau angka romawi jangan ubah
 function set_ucwords($data)
 {
-	if (is_angka_romawi($data)) return $data;
-	return ucwords(strtolower($data));
+	$exp = explode(' ', $data);
+
+	$data = '';
+	for ($i = 0; $i < count($exp); $i++)
+	{
+		$data .= " " . (is_angka_romawi($exp[$i]) ?  $exp[$i] : ucwords(strtolower($exp[$i])));
+	}
+
+	return $data;
 }
 
 function persen($data)


### PR DESCRIPTION
Solusi untuk {perbaikan|fitur baru} terkait issue #3617, #3771

Contoh :
1. III => III
2. KATIMBANG III => Katimbang III (pemisah adalah spasi 1)
3. I KATIMBANG IV =>I Katimbang IV (pemisah adalah spasi 1)

Jika ada kasus lain misalnya:
1. KATIMBANG-IV => Katimbang-Iv (pemisah selain spasi 1)

Jadi solusi di atas hanya untuk kasus nama wilayah/lainnya yg lebih dari 1 kata menggunakan pemisah spasi.

