### PR TITLE
Fix #4113 Double Escape di Autocomplete

### DIFF
--- a/donjo-app/core/MY_Model.php
+++ b/donjo-app/core/MY_Model.php
@@ -53,7 +53,6 @@ class MY_Model extends CI_Model {
 	{
 		if ($cari)
 		{
-			$cari = $this->db->escape_like_str($cari);
 			$this->db->like($kolom, $cari);
 		}
 		$data = $this->db->distinct()->


### PR DESCRIPTION
Solusi untuk perbaikan terkait issue #4113

Fungsi: `$this->db->like()` defaultnya akan meng-escape, jadi tidak perlu di escape lagi.

https://github.com/OpenSID/OpenSID/blob/b007489dc958012330caaeaab61e9ee7233c4c76/system/database/DB_query_builder.php#L953

https://github.com/OpenSID/OpenSID/blob/b007489dc958012330caaeaab61e9ee7233c4c76/system/database/DB_driver.php#L308
