### PR TITLE
Tambah Fitur Lihat Dokumen pada Buku Administrasi Umum (Peraturan Desa, Keputusan Kepala Desa, Surat Masuk)

### DIFF
--- a/donjo-app/controllers/buku_umum/Dokumen_sekretariat.php
+++ b/donjo-app/controllers/buku_umum/Dokumen_sekretariat.php
@@ -228,4 +228,34 @@ class Dokumen_sekretariat extends Admin_Controller {
 				break;
 		}
 	}
+
+	// Melihat Dokumen Sekretariat
+	// Bug : Hanya bisa menampilkan file dengan ekstensi pdf dan file image
+	public function lihat_dokumen($id = '')
+	{
+		$dokumen = $this->web_dokumen_model->get_dokumen($id);
+		$nama_file = $dokumen['satuan'];
+		$pathBerkas = FCPATH . LOKASI_DOKUMEN . $nama_file;
+		$pathBerkas = str_replace('/', DIRECTORY_SEPARATOR, $pathBerkas);
+		$file_extension = strtolower(substr(strrchr($nama_file,"."),1));
+
+		if (!file_exists($pathBerkas)) {
+			http_response_code(404);
+            include(FCPATH . 'donjo-app/views/errors/html/error_404.php');
+            die();
+		}else{
+			switch( $file_extension ) {
+				case "gif": $ctype="image/gif"; break;
+				case "png": $ctype="image/png"; break;
+				case "jpeg": $ctype="image/jpeg"; break;
+				case "jpg": $ctype="image/jpeg"; break;
+				case "svg": $ctype="image/svg+xml"; break;
+				case "pdf" : $ctype="application/pdf"; break;
+				default: 
+			}
+			$tofile = realpath($pathBerkas);
+        	header('Content-Type: ' . $ctype);
+        	return readfile($tofile);
+		}
+	}
 }

--- a/donjo-app/controllers/buku_umum/Surat_masuk.php
+++ b/donjo-app/controllers/buku_umum/Surat_masuk.php
@@ -269,4 +269,34 @@ class Surat_masuk extends Admin_Controller {
 			$hasil = $this->penomoran_surat_model->nomor_surat_duplikat('surat_masuk', $_POST['nomor_urut']);
    	echo $hasil ? 'false' : 'true';
 	}
+
+	// Melihat Dokumen Surat Masuk
+	// Bug : Hanya bisa menampilkan file dengan ekstensi pdf dan file image
+	public function lihat_dokumen($id = '')
+	{
+		$dokumen = $this->surat_masuk_model->getNamaBerkasScan($id);
+		$nama_file = $dokumen;
+		$pathBerkas = FCPATH . LOKASI_ARSIP . $nama_file;
+		$pathBerkas = str_replace('/', DIRECTORY_SEPARATOR, $pathBerkas);
+		$file_extension = strtolower(substr(strrchr($nama_file,"."),1));
+
+		if (!file_exists($pathBerkas)) {
+			http_response_code(404);
+            include(FCPATH . 'donjo-app/views/errors/html/error_404.php');
+            die();
+		}else{
+			switch( $file_extension ) {
+				case "gif": $ctype="image/gif"; break;
+				case "png": $ctype="image/png"; break;
+				case "jpeg": $ctype="image/jpeg"; break;
+				case "jpg": $ctype="image/jpeg"; break;
+				case "svg": $ctype="image/svg+xml"; break;
+				case "pdf" : $ctype="application/pdf"; break;
+				default: 
+			}
+			$tofile = realpath($pathBerkas);
+        	header('Content-Type: ' . $ctype);
+        	return readfile($tofile);
+		}
+	}
 }

--- a/donjo-app/views/dokumen/table_buku_umum.php
+++ b/donjo-app/views/dokumen/table_buku_umum.php
@@ -126,6 +126,7 @@ $(document).ready(function()
 													<td><?=$data['no']?></td>
 													<td nowrap>
 														<a href="<?= site_url("{$this->controller}/form/$kat/$p/$o/$data[id]")?>" class="btn btn-warning btn-flat btn-sm"  title="Ubah"><i class="fa fa-edit"></i></a>
+														<a href="<?= site_url("{$this->controller}/lihat_dokumen/$data[id]")?>" target="_blank" class="btn btn-info btn-flat btn-sm"  title="Lihat Dokumen"><i class="fa fa-eye"></i></a>
 														<?php if ($data['enabled'] == '2'): ?>
 															<a href="<?= site_url($this->controller.'/dokumen_lock/'.$kat.'/'.$data['id'])?>" class="btn bg-navy btn-flat btn-sm"  title="Aktifkan"><i class="fa fa-lock">&nbsp;</i></a>
 														<?php elseif ($data['enabled'] == '1'): ?>

--- a/donjo-app/views/surat_masuk/table.php
+++ b/donjo-app/views/surat_masuk/table.php
@@ -93,6 +93,7 @@
 													<td><?= $data['nomor_urut']?></td>
 													<td class="nostretch">
 														<a href="<?= site_url("surat_masuk/form/$p/$o/$data[id]")?>" class="btn bg-orange btn-flat btn-sm"  title="Ubah Data"><i class="fa fa-edit"></i></a>
+														<a href="<?= site_url("surat_masuk/lihat_dokumen/$data[id]")?>" target="_blank" class="btn btn-info btn-flat btn-sm"  title="Lihat Dokumen"><i class="fa fa-eye"></i></a>
 														<?php if ($data['berkas_scan']): ?>
 															<a href="<?= base_url(LOKASI_ARSIP.$data['berkas_scan'])?>" class="btn bg-purple btn-flat btn-sm"  title="Unduh Berkas Surat" target="_blank"><i class="fa fa-download"></i></a>
 														<?php endif; ?>


### PR DESCRIPTION
Solusi untuk Fitur Baru terkait issue #4411

Solusi yang diusulkan yaitu menambah tombol Lihat Dokumen pada kolom Aksi di menu Buku Administradi Desa :
1. Buku Peraturan Desa
![image](https://user-images.githubusercontent.com/50396709/146120507-2d8f45f1-e0c1-4b34-aa8f-d3759bdb6878.png)

2. Buku Keputusan Kepala Desa
![image](https://user-images.githubusercontent.com/50396709/146120596-70dbf1f3-b25e-41df-83bc-255c0570cae2.png)

3. Buku Agenda - Surat Masuk
![image](https://user-images.githubusercontent.com/50396709/146120631-3691a745-914c-4c5e-89fa-42e8ddff712a.png)

**Contoh Jika Terdapat Dokumen Bentuk File Gambar  :**
![image](https://user-images.githubusercontent.com/50396709/146120710-045287e9-9072-454a-befa-925bc9815b0f.png)

**Contoh Jika Terdapat Dokumen Bentuk File PDF:**
![image](https://user-images.githubusercontent.com/50396709/146120852-829d1a83-3381-43d1-8811-8003e36a1e4d.png)

**Contoh Jika Tidak Terdapat Dokumen :**
![image](https://user-images.githubusercontent.com/50396709/146120924-0bd68b18-7f70-4f1f-b2bf-f658a0e0fc08.png)


**Kelemahan : Hanya bisa dilihat untuk file gambar dan pdf**


**Versi OpenSID : dev-22.01**
