### PR TITLE
penambahan single quote ( `'` ) pada opsi `order_by`

### DIFF
--- a/donjo-app/models/Mandiri_model.php
+++ b/donjo-app/models/Mandiri_model.php
@@ -108,13 +108,13 @@ class Mandiri_model extends CI_Model {
 		switch ($o)
 		{
 			case 1: $this->db->order_by('p.nik'); break;
-			case 2: $this->db->order_by('p.nik', DESC); break;
+			case 2: $this->db->order_by('p.nik', 'DESC'); break;
 			case 3: $this->db->order_by('p.nama'); break;
-			case 4: $this->db->order_by('p.nama', DESC); break;
+			case 4: $this->db->order_by('p.nama', 'DESC'); break;
 			case 5: $this->db->order_by('pm.tanggal_buat'); break;
-			case 6: $this->db->order_by('pm.tanggal_buat', DESC); break;
+			case 6: $this->db->order_by('pm.tanggal_buat', 'DESC'); break;
 			case 7: $this->db->order_by('pm.last_login'); break;
-			case 8: $this->db->order_by('pm.last_login', DESC); break;
+			case 8: $this->db->order_by('pm.last_login', 'DESC'); break;
 			default: '';
 		}
 


### PR DESCRIPTION
baca: https://codeigniter.com/userguide3/database/query_builder.html#ordering-results

menggantikan #4626 
tidak bisa diganti branch-nya karena sudah dihapus

__

<!-- 
Solusi untuk {perbaikan|fitur baru} terkait issue {#1, #2, #3, dst.}

Cek : 
1. [Aturan Penulisan Script.](https://github.com/OpenSID/OpenSID/wiki/Aturan-Penulisan-Script)
2. [Proses Review Pull Request.](https://github.com/OpenSID/OpenSID/wiki/proses-review-pull-request)
-->