### PR TITLE
Tambahkan browser Edge yang berbasis Chromium

### DIFF
--- a/donjo-app/config/user_agents.php
+++ b/donjo-app/config/user_agents.php
@@ -62,6 +62,7 @@ $browsers = [
 	'OPR'               => 'Opera',
 	'Flock'             => 'Flock',
 	'Edge'              => 'Spartan',
+	'Edg'               => 'Edge',
 	'Chrome'            => 'Chrome',
 	// Opera 10+ always reports Opera/9.80 and appends Version/<real version> to the user agent string
 	'Opera.*?Version'   => 'Opera',


### PR DESCRIPTION
Semenjak Ms Edge berbasis Chromium, 
Browser Ms Edge masih terdeteksi sebagai browser Chrome

Sebelum PR
![image](https://user-images.githubusercontent.com/2387514/148384689-00a5e175-9970-4602-8301-8543c4bedc9a.png)

Sesudah PR
![image](https://user-images.githubusercontent.com/2387514/148384812-68a35fad-42e8-4f96-9ab3-2c37c497d831.png)
