### PR TITLE
penambahan config platform php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,11 @@
 			"App\\": "app/"
 		}
 	},
+	"config": {
+		"platform": {
+			"php": "7.3"
+		}
+	},
 	"extra": {
 		"google/apiclient-services": [
 			"Script",


### PR DESCRIPTION
Dalam `composer.json` diperlukan minimal menggunakan php v7.3
Dan kita tidak tahu pengguna menggunakan versi php yang mana, 
kemungkinan masih ada yang menggunakan php v7.3 tapi dalam direktori vendor yang terinstal ada yang php v7.4
akan bisa menjadi masalah (error) jika jika versi php tidak sesuai.

Mungkin bisa diatasi dengan hapus direktori vendor dan lakukan `composer update` 
akan tetapi disini kasusnya adalah tinggal pakai, tidak perlu aksi tambahan yang saya sebutkan
lagi pula direktori vendor masih disertakan dalam paket ZIP.

Ini juga bermanfaat untuk menyesuaikan developer yang beda versi pada PHP nya.

CMIIW

<!-- 
Solusi untuk {perbaikan|fitur baru} terkait issue {#1, #2, #3, dst.}

Cek : 
1. [Aturan Penulisan Script.](https://github.com/OpenSID/OpenSID/wiki/Aturan-Penulisan-Script)
2. [Proses Review Pull Request.](https://github.com/OpenSID/OpenSID/wiki/proses-review-pull-request)
-->