### PR TITLE
perbaikan kesalahan format installed.json

### DIFF
--- a/vendor/composer/installed.json
+++ b/vendor/composer/installed.json
@@ -1,3 +1,4 @@
+{
     "packages": [
         {
             "name": "agungsugiarto/codeigniter-datables",


### PR DESCRIPTION
Tidak bisa menjalankan `composer install` 
![image](https://github.com/OpenSID/OpenSID/assets/2387514/27ffcd8a-2120-4d56-b9fb-bea2e3fe1c7f)

bagian direktori vendor yang ada, mungkin terhapus secara tidak sengaja.
ini tidak saya temukan di versi rilis premium
<!--
Cek : 
1. [Aturan Penulisan Script.](https://github.com/OpenSID/OpenSID/wiki/Aturan-Penulisan-Script)
2. [Proses Review Pull Request.](https://github.com/OpenSID/OpenSID/wiki/proses-review-pull-request)
-->