### PR TITLE
Issue 7052 - Ketika pilih anak atau cucu status perkawinan otomatis belum kawin

### DIFF
--- a/donjo-app/views/sid/kependudukan/penduduk_form_isian_bersama.php
+++ b/donjo-app/views/sid/kependudukan/penduduk_form_isian_bersama.php
@@ -689,6 +689,8 @@
 			maxDate: 'now',
 		});
 
+		var jenis_peristiwa = <?php echo json_encode($jenis_peristiwa); ?>;
+
 		var addOrRemoveRequiredAttribute = function() {
 			var tglsekarang = new Date();
 			var tgllahir = parseInt($('#tgl_lahir').val().substring(6, 10));
@@ -715,6 +717,8 @@
 
 			if (selected == 2 || selected == 3) {
 				$("#status_perkawinan").val("2").change();
+			} else if ((selected == 4 || selected == 6) && jenis_peristiwa == 1) {
+				$("#status_perkawinan").val("1").change();
 			} else {
 				$("#status_perkawinan").val("").change();
 			}


### PR DESCRIPTION
Solusi untuk  issue https://github.com/OpenSID/OpenSID/issues/7052

Saya manambahkan kondisi ketika Hubungan Dalam Keluarga yang dipilih adalah ANAK atau CUCU maka status perkawinan otomatis menjadi BELUM KAWIN. Khusus pada Tambah Penduduk Lahir

Regards,
I Nyoman Jyotisa