### PR TITLE
Fitur: Menambahkan gh action + ansible

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,8 @@
 name: Deploy OpenSID with Ansible
 
 on:
-  pull_request:
-    branches:
-      - dev
+  release:
+    types: [published]
 
 jobs:
   deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,26 @@
+name: Deploy OpenSID with Ansible
+
+on:
+  pull_request:
+    branches:
+      - dev
+
+jobs:
+  deploy:
+    name: Deploy to Production Server
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Ansible Code
+        uses: actions/checkout@v3
+
+      - name: Deploy via SSH using appleboy/ssh-action
+        uses: appleboy/ssh-action@v1.0.0
+        with:
+          host: ${{ secrets.CICD_SERVER_IP }}
+          username: ${{ secrets.CICD_SERVER_USER }}
+          key: ${{ secrets.CICD_SERVER_PRIVATE_KEY }}
+          port: ${{ secrets.CICD_SERVER_PORT }}
+          script: |
+            cd /opt/ansible
+            ansible-playbook -v -i inventories/production/inventory.yml playbooks/deploy-opensid.yml

--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -4,9 +4,12 @@ on:
   pull_request:
     branches:
       - dev
+    types:
+      - closed   # hanya saat PR ditutup
 
 jobs:
   deploy:
+    if: github.event.pull_request.merged == true
     name: Deploy OpenSID to Production Server
     runs-on: ubuntu-latest
 

--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -2,8 +2,8 @@ name: Deploy OpenSID Dev with Ansible
 
 on:
   pull_request:
-    branches: [ "dev" ]
-    # types: [ closed ]
+    branches: [dev]
+    types: [closed]
 
 permissions:
   contents: read
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   deploy:
-    # if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true
     name: Deploy OpenSID Dev to Dev Server
     runs-on: ubuntu-latest
 

--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   deploy:
-    if: github.event.pull_request.merged == true
+    # if: github.event.pull_request.merged == true
     name: Deploy OpenSID Dev to Dev Server
     runs-on: ubuntu-latest
 

--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -1,12 +1,13 @@
 name: Deploy OpenSID with Ansible
 
 on:
-  release:
-    types: [published]
+  pull_request:
+    branches:
+      - dev
 
 jobs:
   deploy:
-    name: Deploy to Production Server
+    name: Deploy OpenSID to Production Server
     runs-on: ubuntu-latest
 
     steps:
@@ -21,5 +22,5 @@ jobs:
           key: ${{ secrets.CICD_SERVER_PRIVATE_KEY }}
           port: ${{ secrets.CICD_SERVER_PORT }}
           script: |
-            cd /opt/ansible
-            ansible-playbook -v -i inventories/production/inventory.yml playbooks/deploy-opensid.yml
+            cd ${{ secrets.CICD_SERVER_PATH }}
+            ansible-playbook -i inventories/production/inventory.yml playbooks/deploy-opensid-dev.yml

--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -1,29 +1,35 @@
-name: Deploy OpenSID with Ansible
+name: Deploy OpenSID Dev with Ansible
 
 on:
   pull_request:
-    branches:
-      - dev
-    types:
-      - closed   # hanya saat PR ditutup
+    branches: [ "dev" ]
+    # types: [ closed ]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-opensid-dev
+  cancel-in-progress: true
 
 jobs:
   deploy:
     if: github.event.pull_request.merged == true
-    name: Deploy OpenSID to Production Server
+    name: Deploy OpenSID Dev to Dev Server
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout Ansible Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Deploy via SSH using appleboy/ssh-action
-        uses: appleboy/ssh-action@v1.0.0
+        uses: appleboy/ssh-action@v1.2.0
         with:
           host: ${{ secrets.CICD_SERVER_IP }}
           username: ${{ secrets.CICD_SERVER_USER }}
           key: ${{ secrets.CICD_SERVER_PRIVATE_KEY }}
           port: ${{ secrets.CICD_SERVER_PORT }}
           script: |
+            set -euo pipefail
             cd ${{ secrets.CICD_SERVER_PATH }}
             ansible-playbook -i inventories/production/inventory.yml playbooks/deploy-opensid-dev.yml

--- a/.github/workflows/deploy_rilis.yml
+++ b/.github/workflows/deploy_rilis.yml
@@ -1,0 +1,26 @@
+name: Deploy OpenSID Rilis with Ansible
+
+on:
+  pull_request:
+    branches:
+      - dev
+
+jobs:
+  deploy:
+    name: Deploy OpenSID Rilis to Production Server
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Ansible Code
+        uses: actions/checkout@v3
+
+      - name: Deploy via SSH using appleboy/ssh-action
+        uses: appleboy/ssh-action@v1.0.0
+        with:
+          host: ${{ secrets.CICD_SERVER_IP }}
+          username: ${{ secrets.CICD_SERVER_USER }}
+          key: ${{ secrets.CICD_SERVER_PRIVATE_KEY }}
+          port: ${{ secrets.CICD_SERVER_PORT }}
+          script: |
+            cd ${{ secrets.CICD_SERVER_PATH }}
+            ansible-playbook -i inventories/production/inventory.yml playbooks/deploy-opensid-rilis.yml

--- a/.github/workflows/deploy_rilis.yml
+++ b/.github/workflows/deploy_rilis.yml
@@ -1,26 +1,34 @@
 name: Deploy OpenSID Rilis with Ansible
 
 on:
-  pull_request:
-    branches:
-      - dev
+  release:
+    types: [ published ]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-opensid-rilis
+  cancel-in-progress: true
 
 jobs:
   deploy:
+    # rilis dari branch 'umum' & bukan prerelease
+    if: github.event.release.target_commitish == 'umum' && github.event.release.prerelease == false
     name: Deploy OpenSID Rilis to Production Server
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout Ansible Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Deploy via SSH using appleboy/ssh-action
-        uses: appleboy/ssh-action@v1.0.0
+        uses: appleboy/ssh-action@v1.2.0
         with:
           host: ${{ secrets.CICD_SERVER_IP }}
           username: ${{ secrets.CICD_SERVER_USER }}
           key: ${{ secrets.CICD_SERVER_PRIVATE_KEY }}
           port: ${{ secrets.CICD_SERVER_PORT }}
           script: |
-            cd ${{ secrets.CICD_SERVER_PATH }}
-            ansible-playbook -i inventories/production/inventory.yml playbooks/deploy-opensid-rilis.yml
+            cd "${{ secrets.CICD_SERVER_PATH }}"
+            ansible-playbook -i inventories/production/inventory.yml playbooks/deploy-opensid-rilis.yml --extra-vars "release_tag=${{ github.event.release.tag_name }}"

--- a/.github/workflows/deploy_rilis.yml
+++ b/.github/workflows/deploy_rilis.yml
@@ -1,11 +1,8 @@
 name: Deploy OpenSID Rilis with Ansible
 
-# on:
-#   release:
-#     types: [published]
 on:
-  pull_request:
-    branches: [dev]
+  release:
+    types: [published]
 
 permissions:
   contents: read
@@ -17,7 +14,7 @@ concurrency:
 jobs:
   deploy:
     # rilis dari branch 'umum' & bukan prerelease
-    # if: github.event.release.target_commitish == 'umum' && github.event.release.prerelease == false
+    if: github.event.release.target_commitish == 'umum' && github.event.release.prerelease == false
     name: Deploy OpenSID Rilis to Production Server
     runs-on: ubuntu-latest
 

--- a/.github/workflows/deploy_rilis.yml
+++ b/.github/workflows/deploy_rilis.yml
@@ -2,7 +2,7 @@ name: Deploy OpenSID Rilis with Ansible
 
 on:
   release:
-    types: [ published ]
+    types: [published]
 
 permissions:
   contents: read

--- a/.github/workflows/deploy_rilis.yml
+++ b/.github/workflows/deploy_rilis.yml
@@ -1,8 +1,11 @@
 name: Deploy OpenSID Rilis with Ansible
 
+# on:
+#   release:
+#     types: [published]
 on:
-  release:
-    types: [published]
+  pull_request:
+    branches: [dev]
 
 permissions:
   contents: read
@@ -14,7 +17,7 @@ concurrency:
 jobs:
   deploy:
     # rilis dari branch 'umum' & bukan prerelease
-    if: github.event.release.target_commitish == 'umum' && github.event.release.prerelease == false
+    # if: github.event.release.target_commitish == 'umum' && github.event.release.prerelease == false
     name: Deploy OpenSID Rilis to Production Server
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Deskripsi
Menambahkan fitur github action deploy otomatis via ansible

### Ada 2 workflow:
**Deploy dev**
- Deploy ke branch `dev`, ketika ada event PR di merge ke `dev` dan status PR nya close
- Akan checkout ke branch `dev`
<img width="1402" height="659" alt="image" src="https://github.com/user-attachments/assets/98212411-f1dc-4fbf-b294-1c29738ff86c" />


**Deploy rilis**
- Deploy ke branch `umum` dengan event rilis publish dan bukan prerelease
- Akan checkout ke `tag` rilis
<img width="1851" height="668" alt="image" src="https://github.com/user-attachments/assets/c9e2bb48-2c2d-41b1-84cd-d85820d04906" />

### Untuk issue:
- https://github.com/OpenSID/DukunganTeknis/issues/366
- https://github.com/OpenSID/DukunganTeknis/issues/361
