### PR TITLE
Optimasi: serve theme_asset langsung lewat Apache tanpa PHP bootstrap

### DIFF
--- a/htaccess.txt
+++ b/htaccess.txt
@@ -11,9 +11,16 @@ RewriteBase /
 # Apabila menggunakan sub-domain atau sub-folder gunakan bentuk berikut
 # RewriteBase /nama-sub-folder/
 
-# Serve theme assets langsung tanpa lewat PHP untuk performa lebih baik
-RewriteCond %{QUERY_STRING} file=([^&]+)
-RewriteRule ^theme_asset/(.+)$ storage/app/themes/$1/assets/%1 [L]
+# Serve theme assets langsung tanpa lewat PHP untuk performa lebih baik.
+# Dukung dua lokasi: storage/app/themes/ (tema sistem) dan desa/themes/ (tema custom desa).
+# Kondisi -f memastikan fallback ke PHP handler jika file tidak ada di lokasi target.
+RewriteCond %{QUERY_STRING} (?:^|&)file=([^&]+)
+RewriteCond %{DOCUMENT_ROOT}/storage/app/themes/$1/assets/%1 -f
+RewriteRule ^theme_asset/([^/]+)/?$ /storage/app/themes/$1/assets/%1 [L]
+
+RewriteCond %{QUERY_STRING} (?:^|&)file=([^&]+)
+RewriteCond %{DOCUMENT_ROOT}/desa/themes/$1/assets/%1 -f
+RewriteRule ^theme_asset/([^/]+)/?$ /desa/themes/$1/assets/%1 [L]
 
 # General dirs / files
 RewriteCond $1 !^(index\.php|resources|robots\.txt)

--- a/htaccess.txt
+++ b/htaccess.txt
@@ -11,6 +11,10 @@ RewriteBase /
 # Apabila menggunakan sub-domain atau sub-folder gunakan bentuk berikut
 # RewriteBase /nama-sub-folder/
 
+# Serve theme assets langsung tanpa lewat PHP untuk performa lebih baik
+RewriteCond %{QUERY_STRING} file=([^&]+)
+RewriteRule ^theme_asset/(.+)$ storage/app/themes/$1/assets/%1 [L]
+
 # General dirs / files
 RewriteCond $1 !^(index\.php|resources|robots\.txt)
 RewriteCond %{REQUEST_FILENAME} !-f


### PR DESCRIPTION
## Deskripsi
Tambah rewrite rule di `htaccess.txt` agar file CSS/JS theme di-serve langsung oleh Apache dari `storage/app/themes/{theme}/assets/` tanpa melewati PHP bootstrap CI3+Eloquent.

Saat ini setiap request `theme_asset/{theme}?file=...` melewati full PHP bootstrap hanya untuk `readfile()` sebuah static file. Halaman depan memuat 8 theme assets, sehingga overhead ini cukup signifikan.

**Benchmark:**
| | Sebelum | Sesudah |
|---|---------|---------|
| Per file | 0.7 - 1.2s | 0.002 - 0.02s |
| Total 8 file | ~7 detik | ~0.05 detik |

## Masalah Terkait (Related Issue)
- Solusi untuk perbaikan terkait issue #10953

## Pull Request Terkait
Tidak ada

## Author
@satyaraya

## Langkah untuk mereproduksi (Steps to Reproduce)
1. Copy `htaccess.txt` ke `.htaccess`
2. Buka halaman depan website
3. Buka browser DevTools → Network tab
4. Perhatikan waktu load file `theme_asset/natra?file=css/bootstrap.min.css` dll
5. Sebelum fix: ~0.7-1.2 detik per file
6. Sesudah fix: ~0.002-0.02 detik per file

## Daftar Periksa (Checklist)
- [x] Saya telah mematuhi [aturan penulisan script](https://github.com/OpenSID/OpenSID/wiki/Aturan-Penulisan-Script).
- [x] Saya telah mengikuti [proses review pull request](https://github.com/OpenSID/OpenSID/wiki/proses-review-pull-request).

## Tangkapan Layar (Screenshot)
Tidak diperlukan — perubahan hanya di `htaccess.txt` (4 baris tambahan rewrite rule).