### PR TITLE
Change validation to exact match for secret code

### DIFF
--- a/app/Rules/SecretCodeRule.php
+++ b/app/Rules/SecretCodeRule.php
@@ -39,7 +39,6 @@ namespace App\Rules;
 
 use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
-use Illuminate\Support\Str;
 
 class SecretCodeRule implements ValidationRule
 {
@@ -52,7 +51,8 @@ class SecretCodeRule implements ValidationRule
      */
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
-        if (! Str::contains($this->secretCode, $value)) {
+        // Exact comparison for secret code validation
+        if ($this->secretCode !== $value) {
             $fail(__('Kode rahasia tidak valid.'));
         }
     }


### PR DESCRIPTION
## Deskripsi
Memperbaiki bug pada `SecretCodeRule` yang sebelumnya menggunakan `Str::contains()` untuk memvalidasi kode rahasia. 
Logika lama menyebabkan validasi lolos meskipun pengguna hanya memasukkan sebagian kecil dari kode rahasia yang benar.

Perubahan:
- Menghapus `use Illuminate\Support\Str` (tidak lagi diperlukan)
- Mengganti `Str::contains()` dengan perbandingan eksak (`!==`)
- Menambahkan komentar singkat untuk menjelaskan fungsi validasi

## Masalah Terkait (Related Issue)
Bug ini ditemukan saat melakukan code review. Saat ini belum ada issue yang membahas masalah ini.

## Pull Request Terkait
Tidak ada

## Author
Dibuat oleh: @nandaanomi 
## Reviewer
(akan ditentukan oleh maintainer)

## Langkah untuk mereproduksi (Steps to Reproduce)
1. Buat instance baru dari SecretCodeRule dengan kode rahasia "RAHASIA123"
2. Inputkan nilai "RAHASIA" (hanya sebagian dari kode)
3. Validasi akan lolos padahal seharusnya gagal
4. Inputkan nilai "RAHASIA123" (kode lengkap) -> validasi lolos

Dengan perubahan ini:
1. Input "RAHASIA" -> validasi gagal (benar)
2. Input "123" -> validasi gagal (benar)
3. Input "RAHASIA123" -> validasi lolos (benar)

## Daftar Periksa (Checklist)
- [x] Saya telah mematuhi [aturan penulisan script](https://github.com/OpenSID/OpenSID/wiki/Aturan-Penulisan-Script).
- [x] Saya telah mengikuti [proses review pull request](https://github.com/OpenSID/OpenSID/wiki/proses-review-pull-request).

## Tangkapan Layar (Screenshot)
(Tidak ada perubahan tampilan, karena ini perubahan logika backend/validasi)