### PR TITLE
🛡️ Batch Dependabot Security Updates - 2026-05-29

### DIFF
--- a/DEPENDABOT_BATCH_20260529_084909.md
+++ b/DEPENDABOT_BATCH_20260529_084909.md
@@ -1,0 +1,28 @@
+# 🛡️ Batch Dependabot Security Updates
+
+Daftar pembaruan keamanan yang perlu ditinjau:
+
+| No | Package | Severity | Summary | Link |
+|---|---|---|---|---|
+| 80 | `symfony/polyfill-intl-idn` | **low** | symfony/polyfill-intl-idn: xn-- labels with ASCII-only Punycode payloads are treated as equivalent to their decoded form | [Detail](https://github.com/OpenSID/OpenSID/security/dependabot/80) |
+| 79 | `symfony/mime` | **medium** | Symfony has Email Header Injection via Non-Token Characters in Mime Parameter Names | [Detail](https://github.com/OpenSID/OpenSID/security/dependabot/79) |
+| 78 | `symfony/mime` | **high** | Symfony has Email Header / SMTP Command Injection via CRLF in SymfonyComponentMimeAddress | [Detail](https://github.com/OpenSID/OpenSID/security/dependabot/78) |
+| 77 | `symfony/mailer` | **medium** | Symfony has an Argument Injection in SendmailTransport via Dash-Prefixed Recipient Address | [Detail](https://github.com/OpenSID/OpenSID/security/dependabot/77) |
+| 76 | `js-cookie` | **high** | JavaScript Cookie: Per-instance prototype hijack in assign() enables cookie-attribute injection | [Detail](https://github.com/OpenSID/OpenSID/security/dependabot/76) |
+| 75 | `fast-uri` | **high** | fast-uri vulnerable to host confusion via percent-encoded authority delimiters | [Detail](https://github.com/OpenSID/OpenSID/security/dependabot/75) |
+| 74 | `fast-uri` | **high** | fast-uri vulnerable to path traversal via percent-encoded dot segments | [Detail](https://github.com/OpenSID/OpenSID/security/dependabot/74) |
+| 73 | `phpseclib/phpseclib` | **high** | phpseclib has a CVE-2024-27355 mitigation bypass — OID amplification DoS in ASN1::decodeOID() | [Detail](https://github.com/OpenSID/OpenSID/security/dependabot/73) |
+| 72 | `postcss` | **medium** | PostCSS has XSS via Unescaped </style> in its CSS Stringify Output | [Detail](https://github.com/OpenSID/OpenSID/security/dependabot/72) |
+| 70 | `phpseclib/phpseclib` | **low** | phpseclib has a variable-time HMAC comparison in SSH2::get_binary_packet() using != instead of hash_equals() | [Detail](https://github.com/OpenSID/OpenSID/security/dependabot/70) |
+| 69 | `lodash` | **high** | lodash vulnerable to Code Injection via `_.template` imports key names | [Detail](https://github.com/OpenSID/OpenSID/security/dependabot/69) |
+| 68 | `lodash` | **medium** | lodash vulnerable to Prototype Pollution via array path bypass in `_.unset` and `_.omit` | [Detail](https://github.com/OpenSID/OpenSID/security/dependabot/68) |
+| 65 | `picomatch` | **medium** | Picomatch: Method Injection in POSIX Character Classes causes incorrect Glob Matching | [Detail](https://github.com/OpenSID/OpenSID/security/dependabot/65) |
+| 63 | `league/commonmark` | **medium** | CommonMark has DisallowedRawHtml extension bypass via whitespace in HTML tag names | [Detail](https://github.com/OpenSID/OpenSID/security/dependabot/63) |
+| 62 | `league/commonmark` | **medium** | league/commonmark has an embed extension allowed_domains bypass | [Detail](https://github.com/OpenSID/OpenSID/security/dependabot/62) |
+| 60 | `phpseclib/phpseclib` | **high** | phpseclib's AES-CBC unpadding susceptible to padding oracle timing attack | [Detail](https://github.com/OpenSID/OpenSID/security/dependabot/60) |
+| 58 | `minimatch` | **high** | minimatch has ReDoS: matchOne() combinatorial backtracking via multiple non-adjacent GLOBSTAR segments | [Detail](https://github.com/OpenSID/OpenSID/security/dependabot/58) |
+| 54 | `firebase/php-jwt` | **low** | php-jwt contains weak encryption | [Detail](https://github.com/OpenSID/OpenSID/security/dependabot/54) |
+| 53 | `symfony/process` | **medium** | Symfony's incorrect argument escaping under MSYS2/Git Bash can lead to destructive file operations on Windows | [Detail](https://github.com/OpenSID/OpenSID/security/dependabot/53) |
+| 52 | `phpunit/phpunit` | **high** | PHPUnit Vulnerable to Unsafe Deserialization in PHPT Code Coverage Handling | [Detail](https://github.com/OpenSID/OpenSID/security/dependabot/52) |
+| 51 | `lodash` | **medium** | Lodash has Prototype Pollution Vulnerability in `_.unset` and `_.omit` functions | [Detail](https://github.com/OpenSID/OpenSID/security/dependabot/51) |
+| 50 | `glob` | **high** | glob CLI: Command injection via -c/--cmd executes matches with shell:true | [Detail](https://github.com/OpenSID/OpenSID/security/dependabot/50) |


### PR DESCRIPTION
# 🛡️ Batch Dependabot Security Updates

Daftar pembaruan keamanan yang perlu ditinjau:

| No | Package | Severity | Summary | Link |
|---|---|---|---|---|
| 80 | `symfony/polyfill-intl-idn` | **low** | symfony/polyfill-intl-idn: xn-- labels with ASCII-only Punycode payloads are treated as equivalent to their decoded form | [Detail](https://github.com/OpenSID/OpenSID/security/dependabot/80) |
| 79 | `symfony/mime` | **medium** | Symfony has Email Header Injection via Non-Token Characters in Mime Parameter Names | [Detail](https://github.com/OpenSID/OpenSID/security/dependabot/79) |
| 78 | `symfony/mime` | **high** | Symfony has Email Header / SMTP Command Injection via CRLF in SymfonyComponentMimeAddress | [Detail](https://github.com/OpenSID/OpenSID/security/dependabot/78) |
| 77 | `symfony/mailer` | **medium** | Symfony has an Argument Injection in SendmailTransport via Dash-Prefixed Recipient Address | [Detail](https://github.com/OpenSID/OpenSID/security/dependabot/77) |
| 76 | `js-cookie` | **high** | JavaScript Cookie: Per-instance prototype hijack in assign() enables cookie-attribute injection | [Detail](https://github.com/OpenSID/OpenSID/security/dependabot/76) |
| 75 | `fast-uri` | **high** | fast-uri vulnerable to host confusion via percent-encoded authority delimiters | [Detail](https://github.com/OpenSID/OpenSID/security/dependabot/75) |
| 74 | `fast-uri` | **high** | fast-uri vulnerable to path traversal via percent-encoded dot segments | [Detail](https://github.com/OpenSID/OpenSID/security/dependabot/74) |
| 73 | `phpseclib/phpseclib` | **high** | phpseclib has a CVE-2024-27355 mitigation bypass — OID amplification DoS in ASN1::decodeOID() | [Detail](https://github.com/OpenSID/OpenSID/security/dependabot/73) |
| 72 | `postcss` | **medium** | PostCSS has XSS via Unescaped </style> in its CSS Stringify Output | [Detail](https://github.com/OpenSID/OpenSID/security/dependabot/72) |
| 70 | `phpseclib/phpseclib` | **low** | phpseclib has a variable-time HMAC comparison in SSH2::get_binary_packet() using != instead of hash_equals() | [Detail](https://github.com/OpenSID/OpenSID/security/dependabot/70) |
| 69 | `lodash` | **high** | lodash vulnerable to Code Injection via `_.template` imports key names | [Detail](https://github.com/OpenSID/OpenSID/security/dependabot/69) |
| 68 | `lodash` | **medium** | lodash vulnerable to Prototype Pollution via array path bypass in `_.unset` and `_.omit` | [Detail](https://github.com/OpenSID/OpenSID/security/dependabot/68) |
| 65 | `picomatch` | **medium** | Picomatch: Method Injection in POSIX Character Classes causes incorrect Glob Matching | [Detail](https://github.com/OpenSID/OpenSID/security/dependabot/65) |
| 63 | `league/commonmark` | **medium** | CommonMark has DisallowedRawHtml extension bypass via whitespace in HTML tag names | [Detail](https://github.com/OpenSID/OpenSID/security/dependabot/63) |
| 62 | `league/commonmark` | **medium** | league/commonmark has an embed extension allowed_domains bypass | [Detail](https://github.com/OpenSID/OpenSID/security/dependabot/62) |
| 60 | `phpseclib/phpseclib` | **high** | phpseclib's AES-CBC unpadding susceptible to padding oracle timing attack | [Detail](https://github.com/OpenSID/OpenSID/security/dependabot/60) |
| 58 | `minimatch` | **high** | minimatch has ReDoS: matchOne() combinatorial backtracking via multiple non-adjacent GLOBSTAR segments | [Detail](https://github.com/OpenSID/OpenSID/security/dependabot/58) |
| 54 | `firebase/php-jwt` | **low** | php-jwt contains weak encryption | [Detail](https://github.com/OpenSID/OpenSID/security/dependabot/54) |
| 53 | `symfony/process` | **medium** | Symfony's incorrect argument escaping under MSYS2/Git Bash can lead to destructive file operations on Windows | [Detail](https://github.com/OpenSID/OpenSID/security/dependabot/53) |
| 52 | `phpunit/phpunit` | **high** | PHPUnit Vulnerable to Unsafe Deserialization in PHPT Code Coverage Handling | [Detail](https://github.com/OpenSID/OpenSID/security/dependabot/52) |
| 51 | `lodash` | **medium** | Lodash has Prototype Pollution Vulnerability in `_.unset` and `_.omit` functions | [Detail](https://github.com/OpenSID/OpenSID/security/dependabot/51) |
| 50 | `glob` | **high** | glob CLI: Command injection via -c/--cmd executes matches with shell:true | [Detail](https://github.com/OpenSID/OpenSID/security/dependabot/50) |
