### PR TITLE
🛡️ Batch Dependabot Security Updates - 2026-05-30

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,7 @@
         "spipu/html2pdf": "^5.2",
         "stechstudio/laravel-zipstream": "^5.0",
         "symfony/console": "^6.1",
-        "symfony/process": "^6.1",
+        "symfony/process": "^6.4.33",
         "symfony/var-dumper": "^6.1",
         "tinymce/tinymce": "^7.2",
         "voku/anti-xss": "^4.1",
@@ -81,7 +81,7 @@
         "friendsofphp/php-cs-fixer": "^3.49",
         "mikey179/vfsstream": "~1.1.0",
         "mockery/mockery": "^1.6",
-        "phpunit/phpunit": "^9.6",
+        "phpunit/phpunit": "^9.6.33",
         "rector/rector": "^1.0"
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
# 🛡️ Batch Dependabot Security Updates

**Repo:** OpenSID/OpenSID
**Date:** 2026-05-30
**PHP Version:** ^8.1
**Total Alerts:** 22
**Packages Updated:** 2

## 📦 Package Updates

| Package | From | To | Type | PHP Req | Status |
|---------|------|-----|------|---------|--------|
| `symfony/process` | ^6.1 | ^6.4.33 | 🟡 minor | N/A | ✅ Updated |
| `phpunit/phpunit` | ^9.6 | ^9.6.33 | 🟢 patch | N/A | ✅ Updated |

## ⚠️ Warnings

- symfony/polyfill-intl-idn: Not found in composer.json
- symfony/mime: Not found in composer.json
- symfony/mime: Not found in composer.json
- symfony/mailer: Not found in composer.json
- js-cookie: Not found in composer.json
- fast-uri: Not found in composer.json
- fast-uri: Not found in composer.json
- phpseclib/phpseclib: Not found in composer.json
- postcss: Not found in composer.json
- phpseclib/phpseclib: Not found in composer.json
- lodash: Not found in composer.json
- lodash: Not found in composer.json
- picomatch: Not found in composer.json
- league/commonmark: Not found in composer.json
- league/commonmark: Not found in composer.json
- phpseclib/phpseclib: Not found in composer.json
- minimatch: Not found in composer.json
- firebase/php-jwt: Not found in composer.json
- lodash: Not found in composer.json
- glob: Not found in composer.json

## 📋 Alert Details

### 🟠 HIGH (10)

| # | Package | Summary |
|---|---------|---------|
| [78](https://github.com/OpenSID/OpenSID/security/dependabot/78) | `symfony/mime` | Symfony has Email Header / SMTP Command Injection via CRLF in SymfonyComponentMimeAddress |
| [76](https://github.com/OpenSID/OpenSID/security/dependabot/76) | `js-cookie` | JavaScript Cookie: Per-instance prototype hijack in assign() enables cookie-attribute injection |
| [75](https://github.com/OpenSID/OpenSID/security/dependabot/75) | `fast-uri` | fast-uri vulnerable to host confusion via percent-encoded authority delimiters |
| [74](https://github.com/OpenSID/OpenSID/security/dependabot/74) | `fast-uri` | fast-uri vulnerable to path traversal via percent-encoded dot segments |
| [73](https://github.com/OpenSID/OpenSID/security/dependabot/73) | `phpseclib/phpseclib` | phpseclib has a CVE-2024-27355 mitigation bypass — OID amplification DoS in ASN1::decodeOID() |
| [69](https://github.com/OpenSID/OpenSID/security/dependabot/69) | `lodash` | lodash vulnerable to Code Injection via `_.template` imports key names |
| [60](https://github.com/OpenSID/OpenSID/security/dependabot/60) | `phpseclib/phpseclib` | phpseclib's AES-CBC unpadding susceptible to padding oracle timing attack |
| [58](https://github.com/OpenSID/OpenSID/security/dependabot/58) | `minimatch` | minimatch has ReDoS: matchOne() combinatorial backtracking via multiple non-adjacent GLOBSTAR segments |
| [52](https://github.com/OpenSID/OpenSID/security/dependabot/52) | `phpunit/phpunit` | PHPUnit Vulnerable to Unsafe Deserialization in PHPT Code Coverage Handling |
| [50](https://github.com/OpenSID/OpenSID/security/dependabot/50) | `glob` | glob CLI: Command injection via -c/--cmd executes matches with shell:true |

### 🟡 MEDIUM (9)

| # | Package | Summary |
|---|---------|---------|
| [79](https://github.com/OpenSID/OpenSID/security/dependabot/79) | `symfony/mime` | Symfony has Email Header Injection via Non-Token Characters in Mime Parameter Names |
| [77](https://github.com/OpenSID/OpenSID/security/dependabot/77) | `symfony/mailer` | Symfony has an Argument Injection in SendmailTransport via Dash-Prefixed Recipient Address |
| [72](https://github.com/OpenSID/OpenSID/security/dependabot/72) | `postcss` | PostCSS has XSS via Unescaped </style> in its CSS Stringify Output |
| [68](https://github.com/OpenSID/OpenSID/security/dependabot/68) | `lodash` | lodash vulnerable to Prototype Pollution via array path bypass in `_.unset` and `_.omit` |
| [65](https://github.com/OpenSID/OpenSID/security/dependabot/65) | `picomatch` | Picomatch: Method Injection in POSIX Character Classes causes incorrect Glob Matching |
| [63](https://github.com/OpenSID/OpenSID/security/dependabot/63) | `league/commonmark` | CommonMark has DisallowedRawHtml extension bypass via whitespace in HTML tag names |
| [62](https://github.com/OpenSID/OpenSID/security/dependabot/62) | `league/commonmark` | league/commonmark has an embed extension allowed_domains bypass |
| [53](https://github.com/OpenSID/OpenSID/security/dependabot/53) | `symfony/process` | Symfony's incorrect argument escaping under MSYS2/Git Bash can lead to destructive file operations on Windows |
| [51](https://github.com/OpenSID/OpenSID/security/dependabot/51) | `lodash` | Lodash has Prototype Pollution Vulnerability in `_.unset` and `_.omit` functions |

### 🔵 LOW (3)

| # | Package | Summary |
|---|---------|---------|
| [80](https://github.com/OpenSID/OpenSID/security/dependabot/80) | `symfony/polyfill-intl-idn` | symfony/polyfill-intl-idn: xn-- labels with ASCII-only Punycode payloads are treated as equivalent to their decoded form |
| [70](https://github.com/OpenSID/OpenSID/security/dependabot/70) | `phpseclib/phpseclib` | phpseclib has a variable-time HMAC comparison in SSH2::get_binary_packet() using != instead of hash_equals() |
| [54](https://github.com/OpenSID/OpenSID/security/dependabot/54) | `firebase/php-jwt` | php-jwt contains weak encryption |

---
🤖 _Auto-generated by Dependabot Monitor_