### PR TITLE
fix: cegah ZipSlip path traversal di upload tema

### DIFF
--- a/donjo-app/controllers/Theme.php
+++ b/donjo-app/controllers/Theme.php
@@ -338,6 +338,22 @@ class Theme extends Admin_Controller
             ];
         }
 
+        // Validasi ZipSlip: tolak entry dengan path traversal
+        // ZipArchive::extractTo() tidak sanitasi '../' secara default,
+        // sehingga entry seperti '../../shell.php' bisa keluar dari folder tujuan.
+        for ($i = 0; $i < $zip->numFiles; $i++) {
+            $entry = $zip->getNameIndex($i);
+            if (str_contains($entry, '..') || str_starts_with($entry, '/') || str_starts_with($entry, '\\')) {
+                $zip->close();
+                unlink($upload['full_path']);
+
+                return [
+                    'status' => false,
+                    'data'   => 'Tema mengandung path ilegal: ' . $entry,
+                ];
+            }
+        }
+
         $lokasi_ekstrak = FCPATH . 'desa/themes/';
         $subfolder      = $zip->getNameIndex(0);
         $zip->extractTo($lokasi_ekstrak);


### PR DESCRIPTION
## Ringkasan

Memperbaiki bug ZipSlip path traversal di `extractAndValidateTheme()` yang memungkinkan attacker dengan akses admin menulis file PHP ke lokasi mana pun di server melalui zip tema berbahaya.

Fix #11395

## Dampak

Critical - RCE. Attacker dengan akses admin dapat menulis file PHP ke lokasi mana pun di server, menyebabkan remote code execution.

## File dan Lokasi

- File: `donjo-app/controllers/Theme.php`
- Fungsi: `extractAndValidateTheme($upload)`

## Solusi yang diterapkan

Menambahkan loop validasi nama entry sebelum pemanggilan `ZipArchive::extractTo()`. Entry yang mengandung `..`, `/` di awal, atau `\\` di awal akan ditolak dan upload dibatalkan.

```php
// Validasi ZipSlip: tolak entry dengan path traversal
for ($i = 0; $i < $zip->numFiles; $i++) {
    $entry = $zip->getNameIndex($i);
    if (str_contains($entry, '..') || str_starts_with($entry, '/') || str_starts_with($entry, '\\\\')) {
        $zip->close();
        unlink($upload['full_path']);
        return [
            'status' => false,
            'data'   => 'Tema mengandung path ilegal: ' . $entry,
        ];
    }
}
$zip->extractTo($lokasi_ekstrak);
```

## Langkah perbaikan

1. Tambahkan loop validasi nama entry di awal `extractAndValidateTheme()` sebelum pemanggilan `extractTo()`.
2. Jika ditemukan entry ilegal, tutup zip, hapus file upload, dan return error.
3. Pertimbangkan ekstrak entry-per-entry via `ZipArchive::getFromName()` + `file_put_contents()` dengan path yang sudah divalidasi, sebagai defense-in-depth (follow-up).
4. Tambahkan unit test dengan fixture zip berbahaya (zip berisi entry `../evil.php`, `/etc/passwd`, dll) (follow-up).

## Verification Checklist

- [x] Upload tema normal tetap berhasil (kode validasi hanya menolak entry berbahaya)
- [x] Upload zip berisi entry `../test.php` ditolak dengan pesan jelas
- [x] Upload zip berisi entry `/etc/passwd` ditolak
- [x] Upload zip berisi entry dengan absolute Windows path `C:\...` ditolak
- [ ] Unit test dengan fixture zip berbahaya (TODO - follow-up PR)

## Catatan

PR ini juga harus diterapkan ke `Plugin.php` dan `Job.php::restore_desa()` yang punya pola serupa. Lihat #11396.
