### PR TITLE
fix: cegah ZipSlip path traversal di Plugin.php dan Job.php restore_desa

### DIFF
--- a/donjo-app/controllers/Job.php
+++ b/donjo-app/controllers/Job.php
@@ -150,6 +150,19 @@ class Job extends CI_Controller
                 // Unzip path
                 $extractpath = DESAPATH . '..';
 
+                // Validasi ZipSlip: tolak entry dengan path traversal
+                // extractpath sudah di parent folder desa, jadi entry '../'
+                // bisa write ke lokasi mana pun - harus divalidasi ketat.
+                for ($i = 0; $i < $zip->numFiles; $i++) {
+                    $entry = $zip->getNameIndex($i);
+                    if (str_contains($entry, '..') || str_starts_with($entry, '/') || str_starts_with($entry, '\\')) {
+                        $zip->close();
+                        $restore->update(['status' => -1]);
+                        log_message('error', "Restore folder desa gagal: backup mengandung path ilegal: {$entry}");
+                        return;
+                    }
+                }
+
                 // Extract file
                 $zip->extractTo($extractpath);
                 $zip->close();

--- a/donjo-app/controllers/Plugin.php
+++ b/donjo-app/controllers/Plugin.php
@@ -331,6 +331,16 @@ class Plugin extends Admin_Controller
                 return redirect_with('error', "Gagal membuka file ZIP: {$zipFilePath}", 'plugin');
             }
 
+            // Validasi ZipSlip: tolak entry dengan path traversal
+            for ($i = 0; $i < $zip->numFiles; $i++) {
+                $entry = $zip->getNameIndex($i);
+                if (str_contains($entry, '..') || str_starts_with($entry, '/') || str_starts_with($entry, '\\')) {
+                    $zip->close();
+                    unlink($zipFilePath);
+                    return redirect_with('error', 'Paket mengandung path ilegal: ' . $entry, 'plugin');
+                }
+            }
+
             $subfolder = rtrim($zip->getNameIndex(0), '/');
             $sourceDir = $tmpExtractedDir . $subfolder;
             $zip->extractTo($tmpExtractedDir);


### PR DESCRIPTION
## Ringkasan

Memperbaiki bug ZipSlip path traversal di dua lokasi:

1. `donjo-app/controllers/Plugin.php` - fungsi `pasangPaket()` yang ekstrak paket tambahan dari marketplace.
2. `donjo-app/controllers/Job.php` - fungsi `restore_desa()` yang ekstrak backup folder desa.

`Job.php::restore_desa()` lebih kritis karena mengekstrak ke `DESAPATH . '..'` (parent folder desa), sehingga zip berbahaya bisa write ke folder mana pun dalam struktur desa.

Fix #11396

## Dampak

Critical - RCE. Attacker yang bisa upload zip berbahaya (via marketplace plugin atau backup folder desa) dapat menulis file PHP ke lokasi mana pun di server, menyebabkan remote code execution. Khususnya `restore_desa()` karena dieksekusi di background job dan mengekstrak ke parent folder desa.

## File dan Lokasi

- File: `donjo-app/controllers/Plugin.php` - fungsi `pasangPaket()`
- File: `donjo-app/controllers/Job.php` - fungsi `restore_desa($id)`

## Solusi yang diterapkan

Menambahkan loop validasi nama entry sebelum `extractTo()` di kedua lokasi. Entry yang mengandung `..`, `/` di awal, atau `\\` di awal akan ditolak.

### Plugin.php

```php
// Validasi ZipSlip: tolak entry dengan path traversal
for ($i = 0; $i < $zip->numFiles; $i++) {
    $entry = $zip->getNameIndex($i);
    if (str_contains($entry, '..') || str_starts_with($entry, '/') || str_starts_with($entry, '\\\\')) {
        $zip->close();
        unlink($zipFilePath);
        return redirect_with('error', 'Paket mengandung path ilegal: ' . $entry, 'plugin');
    }
}
$zip->extractTo($tmpExtractedDir);
```

### Job.php

```php
// Validasi ZipSlip: tolak entry dengan path traversal
for ($i = 0; $i < $zip->numFiles; $i++) {
    $entry = $zip->getNameIndex($i);
    if (str_contains($entry, '..') || str_starts_with($entry, '/') || str_starts_with($entry, '\\\\')) {
        $zip->close();
        $restore->update(['status' => -1]);
        log_message('error', "Restore folder desa gagal: backup mengandung path ilegal: {$entry}");
        return;
    }
}
$zip->extractTo($extractpath);
```

## Langkah perbaikan

1. Tambahkan loop validasi nama entry di `Plugin.php::pasangPaket()` sebelum `extractTo()`.
2. Tambahkan loop validasi nama entry di `Job.php::restore_desa()` sebelum `extractTo()`.
3. Untuk `restore_desa()`, jika entry ilegal ditemukan, update status menjadi `-1` (gagal) dan log error.
4. Pertimbangkan membuat helper function `validateZipEntries(ZipArchive $zip): bool` yang reusable, lalu panggil di `Theme.php`, `Plugin.php`, dan `Job.php` (follow-up PR).

## Verification Checklist

- [x] Install paket tambahan normal tetap berhasil
- [x] Restore folder desa normal tetap berhasil
- [x] Zip berisi entry `../test.php` ditolak di kedua lokasi
- [x] Zip berisi absolute path ditolak
- [x] Log error tercatat saat entry ilegal ditemukan di `restore_desa()`

## Catatan

PR ini melengkapi PR #11395 (Theme.php). Ketiga lokasi punya pola ZipSlip yang sama. Pertimbangkan membuat helper reusable di follow-up.
