### PR TITLE
fix: ganti unserialize dengan json_decode di cache helper idm dan sdgs

### DIFF
--- a/donjo-app/helpers/opensid_helper.php
+++ b/donjo-app/helpers/opensid_helper.php
@@ -1368,8 +1368,16 @@ function idm($kode_desa, $tahun)
 
     // Periksa apakah file cache ada dan tidak kadaluarsa
     if (file_exists($cache_path)) {
-        $data = unserialize(file_get_contents($cache_path));
-        $ci->cache->save($cache, $data['data'], YEAR); // Ubah ke satu tahun
+        $raw  = file_get_contents($cache_path);
+        $data = json_decode($raw, true);
+
+        // Hapus cache corrupt (format lama PHP serialized atau JSON invalid)
+        if (! is_array($data) || ! isset($data['data'])) {
+            @unlink($cache_path);
+            $data = null;
+        } else {
+            $ci->cache->save($cache, $data['data'], YEAR); // Ubah ke satu tahun
+        }
     }
 
     // Ambil cache IDM
@@ -1429,8 +1437,16 @@ function sdgs()
 
     // Periksa apakah file cache ada dan perbaharui cache jika kadaluarsa
     if (file_exists($cache_path)) {
-        $data = unserialize(file_get_contents($cache_path));
-        $ci->cache->save($cache, $data['data'], YEAR); // Ubah ke satu tahun
+        $raw  = file_get_contents($cache_path);
+        $data = json_decode($raw, true);
+
+        // Hapus cache corrupt (format lama PHP serialized atau JSON invalid)
+        if (! is_array($data) || ! isset($data['data'])) {
+            @unlink($cache_path);
+            $data = null;
+        } else {
+            $ci->cache->save($cache, $data['data'], YEAR); // Ubah ke satu tahun
+        }
     }
 
     // Ambil cache SDGs


### PR DESCRIPTION
## Ringkasan

Memperbaiki bug PHP Object Injection (POI) di `donjo-app/helpers/opensid_helper.php` pada fungsi `idm()` dan `sdgs()`. Kedua fungsi memakai `unserialize(file_get_contents(...))` untuk membaca cache dari file `desa/cache/*.json`. `unserialize()` pada data yang tidak terpercaya adalah vektor PHP Object Injection yang dapat menyebabkan RCE jika ada gadget chain yang cocok di codebase (Laravel dan CI3 punya banyak magic methods `__destruct`, `__wakeup`, `__toString`).

Extension file cache adalah `.json`, tetapi isinya dibaca dengan `unserialize()` (format PHP serialized) - ini mengindikasikan bug latent di mana format file dan parser tidak cocok.

Fix #11397

## Dampak

Critical - PHP Object Injection yang dapat menyebabkan RCE jika ada gadget chain. Walaupun butuh write access ke folder cache sebagai prasyarat, bug ini menjadi pengganda (force multiplier) untuk bug lain seperti ZipSlip (#11395, #11396).

## File dan Lokasi

- File: `donjo-app/helpers/opensid_helper.php`
- Baris: 1371 (fungsi `idm()`) dan 1432 (fungsi `sdgs()`)

## Solusi yang diterapkan

Mengganti `unserialize(file_get_contents(...))` dengan `json_decode(file_get_contents(...), true)` di kedua fungsi. Extension file cache memang `.json`, jadi parser yang benar adalah `json_decode`. Selain itu, ditambahkan validasi: jika cache corrupt (bukan array valid atau tidak ada key `data`), file cache dihapus otomatis dan akan di-rebuild saat request berikutnya.

### Sebelum

```php
if (file_exists($cache_path)) {
    $data = unserialize(file_get_contents($cache_path));
    $ci->cache->save($cache, $data['data'], YEAR);
}
```

### Sesudah

```php
if (file_exists($cache_path)) {
    $raw  = file_get_contents($cache_path);
    $data = json_decode($raw, true);

    // Hapus cache corrupt (format lama PHP serialized atau JSON invalid)
    if (! is_array($data) || ! isset($data['data'])) {
        @unlink($cache_path);
        $data = null;
    } else {
        $ci->cache->save($cache, $data['data'], YEAR);
    }
}
```

## Langkah perbaikan

1. Ganti `unserialize(file_get_contents(...))` ke `json_decode(file_get_contents(...), true)` di fungsi `idm()` baris 1371.
2. Lakukan hal sama di fungsi `sdgs()` baris 1432.
3. Tambahkan validasi: jika `json_decode` return `null` atau bukan array, hapus file cache corrupt.
4. Cache lama (format PHP serialized) akan otomatis dihapus saat pertama kali dibaca karena `json_decode` return `null` untuk format PHP serialized.
5. Tidak perlu migrasi khusus - cache akan rebuild otomatis dari API IDM/SDGs saat request berikutnya.
6. Audit lokasi lain dengan pola `unserialize(file_get_contents(...))` di codebase (TODO - follow-up).

## Verification Checklist

- [x] Fungsi `idm()` tidak lagi memakai `unserialize()`
- [x] Fungsi `sdgs()` tidak lagi memakai `unserialize()`
- [x] Cache lama (format PHP serialized) otomatis dihapus saat dibaca
- [x] Cache corrupt (JSON invalid) otomatis dihapus
- [x] Cache rebuild otomatis dari API IDM/SDGs saat cache hilang
- [ ] Test: pastikan tidak ada fatal error saat cache corrupt

## Catatan

PR ini tidak break backward compatibility karena cache akan rebuild otomatis. Cache lama (PHP serialized) akan dihapus pada first read dan di-rebuild dari API.
