### PR TITLE
Tambah centang No. KK pada modal Isian Penduduk Luar

### DIFF
--- a/resources/views/admin/pengaturan_surat/partials/modal_sumber_penduduk.blade.php
+++ b/resources/views/admin/pengaturan_surat/partials/modal_sumber_penduduk.blade.php
@@ -76,6 +76,9 @@
                                         <div class="checkbox">
                                             <label><input type="checkbox" data-id="nama_ibu"> Nama Ibu</label>
                                         </div>
+                                        <div class="checkbox">
+                                            <label><input type="checkbox" data-id="no_kk"> No. KK</label>
+                                        </div>
                                     </div>
                                 </div>
                             </div>

--- a/resources/views/admin/surat_dinas/pengaturan/partials/modal_sumber_penduduk.blade.php
+++ b/resources/views/admin/surat_dinas/pengaturan/partials/modal_sumber_penduduk.blade.php
@@ -76,6 +76,9 @@
                                         <div class="checkbox">
                                             <label><input type="checkbox" data-id="nama_ibu"> Nama Ibu</label>
                                         </div>
+                                        <div class="checkbox">
+                                            <label><input type="checkbox" data-id="no_kk"> No. KK</label>
+                                        </div>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
## Masalah Terkait (Related Issue)
- Solusi untuk fitur baru terkait issue #11349

## Deskripsi
Menambahkan centang "No. KK" di modal "Isian Penduduk Luar" pada pengaturan surat. Field `no_kk` sebenarnya sudah didukung di form isian penduduk luar dan di kode isian surat, cuma checkbox-nya di modal pengaturan yang belum ada. Ditambahkan di dua tempat yang pakai modal sama: pengaturan surat biasa dan surat dinas.

## Langkah untuk mereproduksi (Steps to Reproduce)
1. Buka menu Surat > Pengaturan (atau Surat Dinas > Pengaturan)
2. Buka tab Sumber Penduduk, klik "Form Penduduk Luar"
3. Di daftar Pilihan Input tidak ada opsi "No. KK", padahal field ini sudah dipakai di `penduduk_luar_desa.blade.php` dan `KodeIsianPendudukLuar.php`
